### PR TITLE
Enable systemd-resolved with LLMNR disabled for NixOS

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -124,6 +124,7 @@
         variant = "";
       };
     };
+    resolved.enable = true; # local DNS cache via stub resolver (127.0.0.53)
     printing.enable = true;
     pulseaudio.enable = false;
     pipewire = {

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -124,7 +124,10 @@
         variant = "";
       };
     };
-    resolved.enable = true; # local DNS cache via stub resolver (127.0.0.53)
+    resolved = {
+      enable = true; # local DNS cache via stub resolver (127.0.0.53)
+      settings.Resolve.LLMNR = "false"; # disable LLMNR to prevent link-local name poisoning
+    };
     printing.enable = true;
     pulseaudio.enable = false;
     pipewire = {


### PR DESCRIPTION
## Summary

Enable systemd-resolved as a local DNS cache on the NixOS host. This reduces repeated DNS lookup latency from ~90–197 ms (router round-trip) to near-zero on cache hits, addressing observed network sluggishness caused by slow PPPoE upstream DNS.

LLMNR is disabled at the same time to eliminate the link-local name-poisoning attack surface that systemd-resolved enables by default.

## Changes

- `services.resolved.enable = true` — activates systemd-resolved; NM is wired up automatically by the NixOS module (no need to set `networking.networkmanager.dns` explicitly)
- `services.resolved.settings.Resolve.LLMNR = "false"` — disables LLMNR responder and resolver

Both settings are placed inside the existing `services = { … }` block for consistency.

## Related Issue

N/A