### PR TITLE
Add ghq with fzf integration

### DIFF
--- a/profiles/home/git/default.nix
+++ b/profiles/home/git/default.nix
@@ -15,6 +15,8 @@
 
       pull.rebase = false;
       push.autoSetupRemote = true;
+
+      ghq.root = "~/projects";
     };
   };
 }

--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -73,6 +73,18 @@ _: {
           fi
           nix build "$1" --json | jq -r '.[].outputs | to_entries[].value' | cachix push gawakawa
       }
+
+      # Select a ghq-managed repository with fzf (preview README) and cd into it
+      ghq-fzf() {
+          local src=$(ghq list | fzf --preview "bat --color=always --style=header,grid --line-range :80 $(ghq root)/{}/README.*")
+          if [ -n "$src" ]; then
+              BUFFER="cd $(ghq root)/$src"
+              zle accept-line
+          fi
+          zle -R -c
+      }
+      zle -N ghq-fzf
+      bindkey '^g' ghq-fzf
     '';
     prezto = {
       enable = true;

--- a/profiles/hosts/packages.nix
+++ b/profiles/hosts/packages.nix
@@ -15,6 +15,7 @@
     git
     gh
     gitmoji-cli
+    ghq
 
     # Development tools
     direnv


### PR DESCRIPTION
## Summary

Introduce `ghq` for managing Git repository clones under a consistent path layout, with an fzf widget to jump between local repositories.

## Changes

- Add `ghq` to `environment.systemPackages` (Version control group) in `profiles/hosts/packages.nix`.
- Set `ghq.root = "~/projects"` in `profiles/home/git/default.nix` so `ghq get owner/repo` clones to `~/projects/github.com/owner/repo`.
- Add a `ghq-fzf` zsh widget (Ctrl+G) in `profiles/home/zsh/default.nix` that lists ghq repositories via fzf with a `bat` README preview and `cd`s into the selection.