### PR TITLE
Add gwq for git worktree management with ghq integration

### DIFF
--- a/overlays/gwq.nix
+++ b/overlays/gwq.nix
@@ -1,0 +1,3 @@
+_: final: _: {
+  gwq = final.callPackage ../packages/gwq.nix { };
+}

--- a/packages/gwq.nix
+++ b/packages/gwq.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gwq";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "d-kuro";
+    repo = "gwq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MfCYFbODWnfPxx+6sLlcMT6tqghgILHB13+ccYqVjBA=";
+  };
+
+  vendorHash = "sha256-4K01Xf1EXl/NVX1loQ76l1bW8QglBAQdvlZSo7J4NPI=";
+
+  subPackages = [ "cmd/gwq" ];
+
+  env.CGO_ENABLED = 0;
+
+  meta = {
+    description = "Git worktree manager with fuzzy finder, integrates with ghq";
+    homepage = "https://github.com/d-kuro/gwq";
+    license = lib.licenses.asl20;
+    mainProgram = "gwq";
+  };
+})

--- a/profiles/home/gwq/default.nix
+++ b/profiles/home/gwq/default.nix
@@ -1,11 +1,16 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 let
   tomlFormat = pkgs.formats.toml { };
 in
 {
   xdg.configFile."gwq/config.toml".source = tomlFormat.generate "gwq-config.toml" {
     worktree = {
-      basedir = "~/projects";
+      basedir = config.programs.git.settings.ghq.root;
       auto_mkdir = true;
     };
     naming = {

--- a/profiles/home/gwq/default.nix
+++ b/profiles/home/gwq/default.nix
@@ -1,0 +1,32 @@
+{ pkgs, lib, ... }:
+let
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  xdg.configFile."gwq/config.toml".source = tomlFormat.generate "gwq-config.toml" {
+    worktree = {
+      basedir = "~/projects";
+      auto_mkdir = true;
+    };
+    naming = {
+      template = "{{.Host}}/{{.Owner}}/{{.Repository}}={{.Branch}}";
+      sanitize_chars = {
+        "/" = "-";
+        ":" = "-";
+      };
+    };
+    finder.preview = true;
+    ui = {
+      icons = true;
+      tilde_home = true;
+    };
+    cd = {
+      launch_shell = false;
+      auto_cd_on_add = false;
+    };
+  };
+
+  programs.zsh.initContent = lib.mkAfter ''
+    source <(gwq completion zsh)
+  '';
+}

--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -13,7 +13,7 @@ _: {
       grep = "rg";
       nrs = "sudo nixos-rebuild switch --flake \"$HOME/.config/nix-config#nixos\" --accept-flake-config --impure";
       drs = "sudo darwin-rebuild switch --flake \"$HOME/.config/nix-config#mac\"";
-      non-nix-nvim = "XDG_CONFIG_HOME=$HOME/projects/lua/non-nix-nvim XDG_DATA_HOME=$HOME/.local/share/non-nix-nvim XDG_STATE_HOME=$HOME/.local/state/non-nix-nvim nix run 'nixpkgs#neovim' --";
+      non-nix-nvim = "XDG_CONFIG_HOME=$HOME/projects/github.com/gawakawa/non-nix-nvim XDG_DATA_HOME=$HOME/.local/share/non-nix-nvim XDG_STATE_HOME=$HOME/.local/state/non-nix-nvim nix run 'nixpkgs#neovim' --";
     };
     initContent = ''
       export PATH=$HOME/.deno/bin:$PATH

--- a/profiles/hosts/packages.nix
+++ b/profiles/hosts/packages.nix
@@ -16,6 +16,7 @@
     gh
     gitmoji-cli
     ghq
+    gwq
 
     # Development tools
     direnv


### PR DESCRIPTION
## Summary

Introduce [gwq](https://github.com/d-kuro/gwq) — a git worktree manager that works like ghq but for worktrees. Follows the gwq official Unified Workflow: both `ghq` clone root and `gwq` worktree basedir point to the same `~/projects`, so `ghq list` naturally enumerates both clones and worktrees. This means the existing `ghq-fzf` (Ctrl+G) works as a unified picker with no modifications.

## Changes

- `packages/gwq.nix` — `buildGoModule` derivation for gwq v0.1.1 (nixpkgs-unpackaged)
- `overlays/gwq.nix` — overlay wiring `callPackage ../packages/gwq.nix {}` into the auto-loaded overlay system
- `profiles/hosts/packages.nix` — add `gwq` to system packages alongside `ghq`
- `profiles/home/gwq/default.nix` — generate `~/.config/gwq/config.toml` via `pkgs.formats.toml`; set `basedir = ~/projects`, `template = {{.Host}}/{{.Owner}}/{{.Repository}}={{.Branch}}` (sibling layout, no nesting), `sanitize_chars = { "/" = "-" }` (branch slashes become dashes); enable `source <(gwq completion zsh)` for in-shell cd

Worktree layout after setup:

```
~/projects/github.com/owner/repo              # ghq clone
~/projects/github.com/owner/repo=feature-x    # gwq worktree (sibling)
```

## Related Issue

Related to #69 (add-ghq)