### PR TITLE
Migrate password store to ghq-managed path

### DIFF
--- a/home/mac/launchd/default.nix
+++ b/home/mac/launchd/default.nix
@@ -14,7 +14,7 @@ in
       KeepAlive = true;
       EnvironmentVariables = {
         GNUPGHOME = "${config.home.homeDirectory}/.gnupg";
-        PASSWORD_STORE_DIR = "${config.home.homeDirectory}/.password-store";
+        PASSWORD_STORE_DIR = config.programs.password-store.settings.PASSWORD_STORE_DIR;
       };
     };
   };

--- a/profiles/home/pass/default.nix
+++ b/profiles/home/pass/default.nix
@@ -1,8 +1,9 @@
+{ config, ... }:
 {
   programs.password-store = {
     enable = true;
     settings = {
-      PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store";
+      PASSWORD_STORE_DIR = "${config.home.homeDirectory}/projects/github.com/gawakawa/password-store";
     };
   };
 }

--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -1,9 +1,6 @@
 _: {
   programs.zsh = {
     enable = true;
-    sessionVariables = {
-      PASSWORD_STORE_DIR = "$HOME/.password-store";
-    };
     shellAliases = {
       v = "nix run ~/.config/nix-config/nvim --";
       c = "claude";


### PR DESCRIPTION
## Summary

Relocate the password store from `~/.password-store` to `~/projects/github.com/gawakawa/password-store` to align with the ghq/gwq repository management layout introduced in #69 and #70.

## Changes

- `profiles/home/pass/default.nix`: Set as the single source of truth for `PASSWORD_STORE_DIR`. Takes `{ config, ... }` and derives the path from `config.home.homeDirectory` to produce an absolute path usable by both session variables and launchd.
- `home/mac/launchd/default.nix`: Replace hardcoded path with a reference to `config.programs.password-store.settings.PASSWORD_STORE_DIR` — no more duplicated literal.
- `profiles/home/zsh/default.nix`: Remove redundant `sessionVariables.PASSWORD_STORE_DIR`; the pass module already exports it via `home.sessionVariables`.