### PR TITLE
Replace static deny rules with PreToolUse hooks for git add/reset --hard

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -39,6 +39,28 @@ in
             ];
           }
         ];
+        PreToolUse = [
+          {
+            matcher = "Bash";
+            hooks =
+              let
+                deny = ifPattern: reason: {
+                  type = "command";
+                  "if" = ifPattern;
+                  command = "~/.claude/deny.sh '${reason}'";
+                };
+                bulkAddReason = "Stage files explicitly by name instead: git add <file>.";
+                resetHardReason = "Use git reset --soft to move HEAD while keeping changes, git revert to undo a commit, or git restore <file> (git checkout -- <file>) to discard specific working-tree changes.";
+              in
+              [
+                (deny "Bash(git add -A:*)" bulkAddReason)
+                (deny "Bash(git add --all:*)" bulkAddReason)
+                (deny "Bash(git add -u:*)" bulkAddReason)
+                (deny "Bash(git add .:*)" bulkAddReason)
+                (deny "Bash(git reset --hard:*)" resetHardReason)
+              ];
+          }
+        ];
       };
       permissions = {
         allow = [
@@ -59,11 +81,6 @@ in
           "Bash(tofu * apply *)"
         ];
         deny = [
-          "Bash(git add -A:*)"
-          "Bash(git add --all:*)"
-          "Bash(git add .:*)"
-          "Bash(git add -u:*)"
-          "Bash(git reset --hard:*)"
           "Bash(git commit --no-verify:*)"
           "Bash(git commit -n:*)"
           "Bash(nix develop:*)"

--- a/profiles/home/claude/scripts/deny.sh
+++ b/profiles/home/claude/scripts/deny.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+jq -n --arg reason "$1" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'


### PR DESCRIPTION
## Summary

Replace static `permissions.deny` rules for `git add` bulk-staging (`-A`, `--all`, `.`, `-u`) and `git reset --hard` with `PreToolUse` hooks that return a `permissionDecisionReason` naming the alternative commands.

Static deny rules give Claude no guidance — the follow-up behavior after a block is poor. By moving the block to a `PreToolUse` hook with `permissionDecisionReason`, Claude receives actionable alternatives and can self-correct.

## Changes

- `profiles/home/claude/scripts/deny.sh` — generic hook script: takes a reason as `$1`, emits `permissionDecision: "deny"` JSON with `permissionDecisionReason`; no command parsing
- `profiles/home/claude/default.nix` — replaces the two old `block-*.sh` handlers with a `deny` nix helper that maps each command pattern (`if` field) + reason to a handler; removes the 5 `git add`/`git reset --hard` entries from `permissions.deny`; reverts `home.file` to the original `readDir ./scripts` form

The `nix develop/shell` and `git commit --no-verify/-n` rules remain as plain static deny.