### PR TITLE
Add review-loop skill

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -69,6 +69,7 @@ in
           "Skill(pr)"
           "Skill(ci-debugger)"
           "Skill(skill-creator)"
+          "Skill(review-loop)"
         ];
         ask = [
           "Bash(rm *)"

--- a/profiles/home/claude/skills/review-loop/SKILL.md
+++ b/profiles/home/claude/skills/review-loop/SKILL.md
@@ -1,86 +1,66 @@
 ---
 name: review-loop
-description: "Iteratively run /code-review, triage which findings need addressing, fix them, and re-review until nothing worth addressing remains. Use when the user wants to clean up the current branch via repeated code review, or says 'review loop', 'レビューループ', 'code-review を回して直して', 'lint until clean'. Optional arg: code-review effort level (low|medium|high|max, default high)."
+description: "One disciplined pass of /code-review -> triage -> fix on the current branch; pair with /goal to repeat until clean or a turn cap. Use when the user says 'review loop', 'レビューループ', 'code-review を回して直して', 'lint until clean'. Optional arg: code-review effort (low|medium|high|max, default high)."
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: Skill(code-review), Skill(commit), Agent, Read, Edit, Write, Bash, Grep, Glob, TaskCreate, TaskUpdate, AskUserQuestion
+allowed-tools: Skill(code-review), Skill(commit), Agent, Read, Edit, Write, Bash, Grep, Glob
 model: opus
 ---
 
 # Review Loop
 
-Run `/code-review` → triage → fix → repeat until the triage finds nothing worth addressing.
+This skill runs **one** pass of `/code-review` → triage → fix and ends by
+printing an exact status line. Repetition is driven by Claude Code's `/goal`,
+which reads that line — not by this skill.
 
-**Safety cap**: 5 rounds maximum. If hit with outstanding findings, report them and stop without committing.
+## Run it as a loop
 
-**Commit policy**: one `/commit` at the very end, only if fixes were applied. No per-round commits.
-
-**Effort**: use the argument if provided (low|medium|high|max), otherwise default to `high`.
-
-## Workflow
-
-Use TaskCreate to track progress.
-
-### Step 1: Setup
-
-- Parse the effort level from the skill argument. Default: `high`.
-- Create a task with title "review-loop" and record `round = 0`, `fixes_applied = false`.
-
-### Step 2: Review (repeat up to MAX_ROUNDS)
-
-Increment `round`. If `round > 5`, go to **Cap Reached**.
-
-Invoke the code-review skill using the Skill tool, passing the effort level as the positional argument (e.g., `args: "high"`). Never pass `--fix` or `--ultra`.
-
-Capture the findings from its inline output.
-
-### Step 3: Triage
-
-Dispatch a read-only Plan subagent (Agent tool, `subagent_type: Plan`) with:
-
-- The full findings from Step 2.
-- The current codebase context (relevant files if needed).
-- Instruction: follow the global problem-solving order — understand the current state, identify the root cause, then propose a fix. For each finding return a JSON-like structured assessment: `needs_fix` (bool), `reason` (why or why not), `root_cause` (if needs_fix), `fix_plan` (concrete steps if needs_fix).
-- Constraint: analysis only — use **only** Read, Grep, and Glob to inspect code. Do **not** run Bash, and do not edit or write any files.
-
-### Step 4: Surface triage
-
-Print the triage summary as a markdown list so the user can see it before fixes land. Format:
+Arm the goal, then invoke the skill:
 
 ```
-## Round N triage
-- [FIX] <finding> — <reason>
-- [SKIP] <finding> — <reason>
+/goal After each turn, read the most recent line beginning "REVIEW-LOOP-STATUS:". Stop if its result is CLEAN, or if its iteration number is 5 or more. Otherwise run one more /review-loop iteration.
+/review-loop high
 ```
 
-### Step 5: Terminate check
+While the condition is unmet, `/goal`'s Stop hook re-drives another turn; this
+skill's instructions stay in context, so each re-drive runs one more iteration.
+When a round prints `REVIEW-LOOP-STATUS: CLEAN` (or iteration 5 is reached) the
+goal auto-clears and the loop ends. Press Esc to stop early. (`/goal` is
+user-only and can't be set from a skill, so you type that one line to arm it.)
 
-If the triage marks **no** finding as `needs_fix`, print "✓ Nothing to address — loop complete." and go to **Commit**.
+## One iteration
 
-### Step 6: Fix
+Every turn — including each `/goal` re-drive — execute this whole section from
+step 1, starting with a **fresh** `/code-review`. Never re-emit a status off a
+previous round or work from stale findings.
 
-Implement each `fix_plan` in the main thread using Edit/Write/Bash. Do NOT commit.
-Set `fixes_applied = true`.
+**Effort**: use the argument if provided (low|medium|high|max); else `high`.
 
-Update the task status, then go back to **Step 2**.
+1. **Review** — invoke the code-review skill via the Skill tool, passing effort
+   as the positional arg (e.g. `args: "high"`). Never `--fix`/`--ultra`. Capture
+   the findings.
+2. **Triage** — dispatch a read-only Plan subagent (Agent, `subagent_type: Plan`)
+   with the findings. Following the global problem-solving order (understand →
+   root cause → fix), return per finding: `needs_fix` (bool), `reason`,
+   `root_cause`, `fix_plan`. Constraint: analysis only — use **only** Read, Grep,
+   and Glob; do **not** run Bash, and do not edit or write any files.
+3. **Surface** — print the triage as a markdown `[FIX]/[SKIP]` list before any
+   fix lands.
+4. **Act**:
+   - If any finding needs fixing → apply each `fix_plan` (Edit/Write/Bash). Do
+     **not** commit. RESULT = `FIXED`.
+   - If nothing needs fixing → if `git status` / `git diff main...HEAD` shows
+     uncommitted fixes from earlier rounds, run `/commit` once to land them all.
+     RESULT = `CLEAN`.
+5. **Conclude** — set `N` = the iteration number on the most recent prior
+   `REVIEW-LOOP-STATUS:` line in this conversation, + 1 (or `1` if none), and
+   print as the **final line**, exactly:
 
----
+   ```
+   REVIEW-LOOP-STATUS: <RESULT> | iteration <N>
+   ```
 
-### Cap Reached
+   This line is the only thing `/goal` reads to decide whether to re-drive.
 
-Report the remaining findings plainly:
-
-```
-⚠️ MAX_ROUNDS (5) reached with outstanding findings:
-<list each unaddressed finding>
-Not committing — decide how to proceed.
-```
-
-Stop. Do not commit.
-
----
-
-### Commit
-
-If `fixes_applied = true`, invoke `/commit` once to commit all changes across all rounds.
-If `fixes_applied = false` (triage found no actionable findings on round 1), report "No changes needed."
+If the loop stops on the turn cap while RESULT was `FIXED`, the applied fixes are
+left **uncommitted** for the user to review and decide on.

--- a/profiles/home/claude/skills/review-loop/SKILL.md
+++ b/profiles/home/claude/skills/review-loop/SKILL.md
@@ -41,7 +41,7 @@ Dispatch a read-only Plan subagent (Agent tool, `subagent_type: Plan`) with:
 - The full findings from Step 2.
 - The current codebase context (relevant files if needed).
 - Instruction: follow the global problem-solving order — understand the current state, identify the root cause, then propose a fix. For each finding return a JSON-like structured assessment: `needs_fix` (bool), `reason` (why or why not), `root_cause` (if needs_fix), `fix_plan` (concrete steps if needs_fix).
-- Constraint: the subagent must NOT edit or write files and must NOT run Bash commands that write to files (no output redirections, no file-creating tools) — analysis only.
+- Constraint: analysis only — use **only** Read, Grep, and Glob to inspect code. Do **not** run Bash, and do not edit or write any files.
 
 ### Step 4: Surface triage
 

--- a/profiles/home/claude/skills/review-loop/SKILL.md
+++ b/profiles/home/claude/skills/review-loop/SKILL.md
@@ -22,17 +22,11 @@ Arm the goal, then invoke the skill:
 /review-loop high
 ```
 
-While the condition is unmet, `/goal`'s Stop hook re-drives another turn; this
-skill's instructions stay in context, so each re-drive runs one more iteration.
-When a round prints `REVIEW-LOOP-STATUS: CLEAN` (or iteration 5 is reached) the
-goal auto-clears and the loop ends. Press Esc to stop early. (`/goal` is
-user-only and can't be set from a skill, so you type that one line to arm it.)
+Press Esc to stop early. (`/goal` is user-only and can't be set from a skill, so you type that one line to arm it.)
 
 ## One iteration
 
-Every turn — including each `/goal` re-drive — execute this whole section from
-step 1, starting with a **fresh** `/code-review`. Never re-emit a status off a
-previous round or work from stale findings.
+Run steps 1–5 in order, starting with a **fresh** `/code-review` each time.
 
 **Effort**: use the argument if provided (low|medium|high|max); else `high`.
 
@@ -42,25 +36,20 @@ previous round or work from stale findings.
    already shows changes, tell the user that the branch has pre-existing uncommitted
    work — the commit step asks which files to stage, so it won't be swept in without
    their selection.
-2. **Triage** — dispatch a read-only Plan subagent (Agent, `subagent_type: Plan`)
-   with the findings. Following the global problem-solving order (understand →
-   root cause → fix), return per finding: `needs_fix` (bool), `reason`,
-   `root_cause`, `fix_plan`. Constraint: analysis only — use **only** Read, Grep,
-   and Glob; do **not** run Bash, and do not edit or write any files.
+2. **Triage** — dispatch a Plan subagent (Agent, `subagent_type: Plan`) with the
+   findings. Per finding return: `needs_fix` (bool), `reason`, `root_cause`,
+   `fix_plan`. Use only Read, Grep, and Glob — do not run Bash.
 3. **Surface** — print the triage as a markdown `[FIX]/[SKIP]` list before any
    fix lands.
 4. **Act**:
    - If any finding needs fixing → apply each `fix_plan` (Edit/Write/Bash). Do
      **not** commit. RESULT = `FIXED`.
-   - If nothing needs fixing → RESULT = `CLEAN`. If `git status --short` shows
-     uncommitted fixes from earlier rounds, run `/commit` once to land them (the
-     commit skill confirms which files to stage).
+   - If nothing needs fixing → RESULT = `CLEAN`.
 5. **Conclude**:
+   - If RESULT is `CLEAN`, run `git status --short`; if non-empty, run `/commit`
+     once (the commit skill confirms which files to stage).
    - Run `git status --short`. If it shows uncommitted changes, say so **loudly**
-     and list them — this covers a `FIXED` round (fixes commit on the final `CLEAN`
-     round, or await your decision if the cap stops the loop here) and a `CLEAN`
-     round whose `/commit` did not land (a stuck commit is for you to resolve, not a
-     reason to re-review).
+     and list them.
    - Set `N` = the iteration number on the most recent prior `REVIEW-LOOP-STATUS:`
      line in this conversation, + 1 (or `1` if none). If `N == 1` and RESULT is
      `FIXED`, remind the user that a bare `/review-loop` runs once — to repeat

--- a/profiles/home/claude/skills/review-loop/SKILL.md
+++ b/profiles/home/claude/skills/review-loop/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: review-loop
+description: "Iteratively run /code-review, triage which findings need addressing, fix them, and re-review until nothing worth addressing remains. Use when the user wants to clean up the current branch via repeated code review, or says 'review loop', 'レビューループ', 'code-review を回して直して', 'lint until clean'. Optional arg: code-review effort level (low|medium|high|max, default high)."
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: Skill(code-review), Skill(commit), Agent, Read, Edit, Write, Bash, Grep, Glob, TaskCreate, TaskUpdate, AskUserQuestion
+model: opus
+---
+
+# Review Loop
+
+Run `/code-review` → triage → fix → repeat until the triage finds nothing worth addressing.
+
+**Safety cap**: 5 rounds maximum. If hit with outstanding findings, report them and stop without committing.
+
+**Commit policy**: one `/commit` at the very end, only if fixes were applied. No per-round commits.
+
+**Effort**: use the argument if provided (low|medium|high|max), otherwise default to `high`.
+
+## Workflow
+
+Use TaskCreate to track progress.
+
+### Step 1: Setup
+
+- Parse the effort level from the skill argument. Default: `high`.
+- Create a task with title "review-loop" and record `round = 0`, `fixes_applied = false`.
+
+### Step 2: Review (repeat up to MAX_ROUNDS)
+
+Increment `round`. If `round > 5`, go to **Cap Reached**.
+
+Invoke the code-review skill using the Skill tool, passing the effort level as the positional argument (e.g., `args: "high"`). Never pass `--fix` or `--ultra`.
+
+Capture the findings from its inline output.
+
+### Step 3: Triage
+
+Dispatch a read-only Plan subagent (Agent tool, `subagent_type: Plan`) with:
+
+- The full findings from Step 2.
+- The current codebase context (relevant files if needed).
+- Instruction: follow the global problem-solving order — understand the current state, identify the root cause, then propose a fix. For each finding return a JSON-like structured assessment: `needs_fix` (bool), `reason` (why or why not), `root_cause` (if needs_fix), `fix_plan` (concrete steps if needs_fix).
+- Constraint: the subagent must NOT edit or write files and must NOT run Bash commands that write to files (no output redirections, no file-creating tools) — analysis only.
+
+### Step 4: Surface triage
+
+Print the triage summary as a markdown list so the user can see it before fixes land. Format:
+
+```
+## Round N triage
+- [FIX] <finding> — <reason>
+- [SKIP] <finding> — <reason>
+```
+
+### Step 5: Terminate check
+
+If the triage marks **no** finding as `needs_fix`, print "✓ Nothing to address — loop complete." and go to **Commit**.
+
+### Step 6: Fix
+
+Implement each `fix_plan` in the main thread using Edit/Write/Bash. Do NOT commit.
+Set `fixes_applied = true`.
+
+Update the task status, then go back to **Step 2**.
+
+---
+
+### Cap Reached
+
+Report the remaining findings plainly:
+
+```
+⚠️ MAX_ROUNDS (5) reached with outstanding findings:
+<list each unaddressed finding>
+Not committing — decide how to proceed.
+```
+
+Stop. Do not commit.
+
+---
+
+### Commit
+
+If `fixes_applied = true`, invoke `/commit` once to commit all changes across all rounds.
+If `fixes_applied = false` (triage found no actionable findings on round 1), report "No changes needed."

--- a/profiles/home/claude/skills/review-loop/SKILL.md
+++ b/profiles/home/claude/skills/review-loop/SKILL.md
@@ -38,7 +38,10 @@ previous round or work from stale findings.
 
 1. **Review** — invoke the code-review skill via the Skill tool, passing effort
    as the positional arg (e.g. `args: "high"`). Never `--fix`/`--ultra`. Capture
-   the findings.
+   the findings. On the **first** iteration (`N` will be 1), if `git status --short`
+   already shows changes, tell the user that the branch has pre-existing uncommitted
+   work — the commit step asks which files to stage, so it won't be swept in without
+   their selection.
 2. **Triage** — dispatch a read-only Plan subagent (Agent, `subagent_type: Plan`)
    with the findings. Following the global problem-solving order (understand →
    root cause → fix), return per finding: `needs_fix` (bool), `reason`,
@@ -49,18 +52,23 @@ previous round or work from stale findings.
 4. **Act**:
    - If any finding needs fixing → apply each `fix_plan` (Edit/Write/Bash). Do
      **not** commit. RESULT = `FIXED`.
-   - If nothing needs fixing → if `git status` / `git diff main...HEAD` shows
-     uncommitted fixes from earlier rounds, run `/commit` once to land them all.
-     RESULT = `CLEAN`.
-5. **Conclude** — set `N` = the iteration number on the most recent prior
-   `REVIEW-LOOP-STATUS:` line in this conversation, + 1 (or `1` if none), and
-   print as the **final line**, exactly:
+   - If nothing needs fixing → RESULT = `CLEAN`. If `git status --short` shows
+     uncommitted fixes from earlier rounds, run `/commit` once to land them (the
+     commit skill confirms which files to stage).
+5. **Conclude**:
+   - Run `git status --short`. If it shows uncommitted changes, say so **loudly**
+     and list them — this covers a `FIXED` round (fixes commit on the final `CLEAN`
+     round, or await your decision if the cap stops the loop here) and a `CLEAN`
+     round whose `/commit` did not land (a stuck commit is for you to resolve, not a
+     reason to re-review).
+   - Set `N` = the iteration number on the most recent prior `REVIEW-LOOP-STATUS:`
+     line in this conversation, + 1 (or `1` if none). If `N == 1` and RESULT is
+     `FIXED`, remind the user that a bare `/review-loop` runs once — to repeat
+     automatically, arm a `/goal` as shown in **Run it as a loop**.
+   - Print as the **final line**, exactly:
 
    ```
    REVIEW-LOOP-STATUS: <RESULT> | iteration <N>
    ```
 
    This line is the only thing `/goal` reads to decide whether to re-drive.
-
-If the loop stops on the turn cap while RESULT was `FIXED`, the applied fixes are
-left **uncommitted** for the user to review and decide on.


### PR DESCRIPTION
## Summary

Add a `/review-loop` Claude Code skill that automates the iterative code-review-and-fix cycle: run `/code-review`, triage which findings genuinely need addressing, fix them, then re-review — repeating until the triage finds nothing worth addressing.

## Changes

- `profiles/home/claude/skills/review-loop/SKILL.md` — new skill with:
  - Effort-level argument (low|medium|high|max, default `high`)
  - 5-round safety cap
  - Read-only Plan subagent for triage (plan-mode-equivalent analysis without the ExitPlanMode approval gate per iteration)
  - Single commit at the end only if fixes were applied
  - Positive allow-list constraint on triage subagent (Read/Grep/Glob only; no Bash)
- `profiles/home/claude/default.nix` — add `Skill(review-loop)` to `permissions.allow`

Permission model: nested `Skill(code-review)`, `Skill(commit)`, and `Agent` calls are pre-approved via the skill's `allowed-tools` frontmatter (documented grant semantics), so no additional global allow entries are needed.

**Post-install acceptance test:** after rebuild, run `/review-loop high` on a branch with a deliberate minor bug and confirm round 2 begins after round 1's review/fix (nested `Skill(code-review)` control-return is still unproven by a live run).