### PR TITLE
Bump default Sonnet model to claude-sonnet-5

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -5,7 +5,7 @@ in
 {
   home.sessionVariables = {
     ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-8";
-    ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-6";
+    ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-5";
     ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
   };


### PR DESCRIPTION
## Summary

`ANTHROPIC_DEFAULT_SONNET_MODEL` を `claude-sonnet-4-6` から最新の `claude-sonnet-5` に更新する。

## Changes

- `profiles/home/claude/default.nix`: `ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-5"`