### PR TITLE
Strip gwq worktree branch suffix from starship directory display

### DIFF
--- a/profiles/home/starship/default.nix
+++ b/profiles/home/starship/default.nix
@@ -36,10 +36,23 @@ in
         truncation_length = 0;
         truncate_to_repo = false;
         home_symbol = nf-md-home;
-        substitutions = {
-          "${nf-md-home}/.config" = nf-md-folder_cog;
-          "${devDir}github.com" = "${nf-dev-github} ";
-        };
+        substitutions = [
+          {
+            from = "${nf-md-home}/.config";
+            to = nf-md-folder_cog;
+          }
+          {
+            from = "${devDir}github.com";
+            to = "${nf-dev-github} ";
+          }
+          {
+            # Strip gwq worktree branch suffix (=<branch>) from directory path.
+            # gwq names worktrees as <repo>=<branch>, causing double display with git_branch.
+            from = "=[^/]+";
+            to = "";
+            regex = true;
+          }
+        ];
       };
 
       git_branch = {


### PR DESCRIPTION
## Summary

gwq を導入後、starship プロンプトでブランチ名が二重表示されていた。gwq の worktree 命名規則 (`<repo>=<branch>`) によりディレクトリ名に `=<branch>` が含まれ、`directory` セグメントと `git_branch` セグメントの両方にブランチ名が現れていた。

`directory.substitutions` に正規表現エントリ `=[^/]+` を追加し、パス表示側から `=<branch>` 接尾辞を除去する。「パス + ブランチ」という構成はそのままにしつつ、重複を解消する。

## Changes

- `profiles/home/starship/default.nix`: `substitutions` を attrset 形式から array-of-tables 形式に変換し、gwq worktree の `=<branch>` 接尾辞を除去する正規表現エントリを追加

  **Before:** `gawakawa/nix-config=starship-gwq [starship-gwq]`  
  **After:** `gawakawa/nix-config [starship-gwq]`

## Notes

- starship 1.25.1 は `[[directory.substitutions]]` (array-of-tables) を正しく処理することを実機確認済み
- 正規表現 `=[^/]+` は最初のマッチのみ置換（starship の仕様）。GitHub の owner/repo 名に `=` は使えないため、false-positive は構造上発生しない
- `$` アンカーを付けると worktree サブディレクトリ内でマッチしなくなるため、意図的にアンカーなしとしている