### PR TITLE
:wrench: Allow nixos MCP server tools without prompts

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -70,6 +70,7 @@ in
           "Skill(ci-debugger)"
           "Skill(skill-creator)"
           "Skill(review-loop)"
+          "mcp__nixos"
         ];
         ask = [
           "Bash(rm *)"


### PR DESCRIPTION
## Summary

Every call to the `nixos` MCP server (`mcp-nixos`) currently triggers a manual permission prompt. This adds it to the user-level Claude Code allowlist so its tools run without confirmation.

## Changes

- Add `"mcp__nixos"` to `programs.claude-code.settings.permissions.allow` in `profiles/home/claude/default.nix`, matching the `nixos` key used to register the MCP server.