### PR TITLE
Drop main-push CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: "CI"
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

All changes land on main via PR, which already runs the full CI check suite. Re-running the same checks again on push to main is redundant, since main is never pushed to directly.

## Changes

- Remove the `push: branches: [main]` trigger from `.github/workflows/ci.yml`, leaving only `pull_request`