### PR TITLE
Strip gwq worktree branch suffix from wezterm & statusline

### DIFF
--- a/profiles/home/claude/scripts/statusline.sh
+++ b/profiles/home/claude/scripts/statusline.sh
@@ -28,5 +28,9 @@ BAR=""
 cd "$CWD" 2>/dev/null || true
 GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 
+# Strip gwq worktree branch suffix (=<branch>) from directory basename
+DIR=${CWD##*/}
+DIR=${DIR%%=*}
+
 # Output format
-echo "📁 ${CWD##*/} ${GIT_BRANCH:+ $GIT_BRANCH }✴️${MODEL} [${BAR}] ${CONTEXT_PERCENT}%"
+echo "📁 ${DIR} ${GIT_BRANCH:+ $GIT_BRANCH }✴️${MODEL} [${BAR}] ${CONTEXT_PERCENT}%"

--- a/profiles/home/wezterm/wezterm.lua
+++ b/profiles/home/wezterm/wezterm.lua
@@ -24,9 +24,9 @@ wezterm.on("format-tab-title", function(tab, _tabs, _panes, _cfg, _hover, max_wi
 	end
 
 	local edge_foreground = background
-	local title = "   "
-		.. wezterm.truncate_right(basename(tab.active_pane.current_working_dir.file_path), max_width - 1)
-		.. "   "
+	local dir = basename(tab.active_pane.current_working_dir.file_path)
+	dir = dir:gsub("=.*", "") -- strip gwq worktree branch suffix (=<branch>)
+	local title = "   " .. wezterm.truncate_right(dir, max_width - 1) .. "   "
 
 	return {
 		{ Background = { Color = edge_background } },


### PR DESCRIPTION
## Summary

gwq names worktrees `<repo>=<branch>` at paths like `~/projects/github.com/gawakawa/nix-config=starship-gwq`. The `=<branch>` suffix duplicates the branch name already shown by `git_branch`/`GIT_BRANCH` elsewhere. A prior commit (50e4eed) fixed this for the starship prompt; this PR applies the same fix to the two remaining places that still showed the redundant suffix: the wezterm tab title and the Claude Code statusline.

## Changes

- `profiles/home/wezterm/wezterm.lua`: strip `=<branch>` from the tab title's directory basename via `dir:gsub("=.*", "")`.
- `profiles/home/claude/scripts/statusline.sh`: strip `=<branch>` from the displayed directory basename via `${DIR%%=*}`, keeping the separate git branch display intact.

Both changes only strip the suffix from the basename, so subdirectories inside a gwq worktree (e.g. `.../nix-config=starship-gwq/profiles`) still display correctly (`profiles`, not truncated).