### PR TITLE
Launch wifitui/bluetui in wezterm from Waybar clicks

### DIFF
--- a/home/nixos/bluetooth/default.nix
+++ b/home/nixos/bluetooth/default.nix
@@ -1,4 +1,4 @@
 { pkgs, ... }:
 {
-  home.packages = [ pkgs.dmenu-bluetooth ];
+  home.packages = [ pkgs.bluetui ];
 }

--- a/home/nixos/networkmanager-dmenu/default.nix
+++ b/home/nixos/networkmanager-dmenu/default.nix
@@ -1,9 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = [ pkgs.networkmanager_dmenu ];
-
-  xdg.configFile."networkmanager-dmenu/config.ini".text = ''
-    [dmenu]
-    dmenu_command = wofi --dmenu
-  '';
-}

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -37,7 +37,7 @@ _: {
           format-wifi = "";
           format-disconnected = "󰤮";
           tooltip-format = "{essid} ({ipaddr})";
-          on-click = "networkmanager_dmenu";
+          on-click = "wezterm start -- wifitui";
         };
 
         bluetooth = {

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -46,7 +46,7 @@ _: {
           format-connected = " {num_connections}";
           tooltip-format = "{controller_alias}\t{controller_address}";
           tooltip-format-connected = "{device_enumerate}";
-          on-click = "DMENU_BLUETOOTH_LAUNCHER='wofi --dmenu' dmenu-bluetooth";
+          on-click = "wezterm start -- bluetui";
         };
       };
     };

--- a/home/nixos/wifitui/default.nix
+++ b/home/nixos/wifitui/default.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.wifitui ];
+}


### PR DESCRIPTION
## Summary

Waybar の network / bluetooth アイコンをクリックした際に開く UI を、簡素な wofi ベースの dmenu ピッカーから、より機能的な TUI（wezterm 上で起動）に変更しました。

## Changes

- network: `networkmanager_dmenu` (wofi dmenu) → `wezterm start -- wifitui`
  - `home/nixos/wifitui/default.nix` を新規追加
  - 不要になった `home/nixos/networkmanager-dmenu/` を削除
- bluetooth: `dmenu-bluetooth` (wofi dmenu) → `wezterm start -- bluetui`
  - `home/nixos/bluetooth/default.nix` のパッケージを `dmenu-bluetooth` から `bluetui` に変更
- 両者とも `home/nixos/waybar/default.nix` の `on-click` を更新
- バックエンドは既存の NetworkManager / bluez をそのまま利用（変更なし）