### PR TITLE
Support gwq worktree branch in nrs/drs

### DIFF
--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -12,8 +12,6 @@ _: {
       ls = "eza -a";
       find = "fd";
       grep = "rg";
-      nrs = "sudo nixos-rebuild switch --flake \"$NIXCFG_DIR#nixos\" --accept-flake-config --impure";
-      drs = "sudo darwin-rebuild switch --flake \"$NIXCFG_DIR#mac\"";
       non-nix-nvim = "XDG_CONFIG_HOME=$HOME/projects/github.com/gawakawa/non-nix-nvim XDG_DATA_HOME=$HOME/.local/share/non-nix-nvim XDG_STATE_HOME=$HOME/.local/state/non-nix-nvim nix run 'nixpkgs#neovim' --";
     };
     initContent = ''
@@ -25,6 +23,17 @@ _: {
 
       mkcd() {
           mkdir -p "$1" && cd "$1"
+      }
+
+      # Rebuild from the nix-config repo, or a gwq worktree when a branch is given
+      # Usage: nrs [branch]  (branch -> nix-config=<branch> worktree)
+      nrs() {
+          sudo nixos-rebuild switch --flake "$NIXCFG_DIR''${1:+=$1}#nixos" --accept-flake-config --impure
+      }
+
+      # Usage: drs [branch]  (branch -> nix-config=<branch> worktree)
+      drs() {
+          sudo darwin-rebuild switch --flake "$NIXCFG_DIR''${1:+=$1}#mac"
       }
 
       # Set GitHub Actions secrets

--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -25,15 +25,28 @@ _: {
           mkdir -p "$1" && cd "$1"
       }
 
-      # Rebuild from the nix-config repo, or a gwq worktree when a branch is given
-      # Usage: nrs [branch]  (branch -> nix-config=<branch> worktree)
-      nrs() {
-          sudo nixos-rebuild switch --flake "$NIXCFG_DIR''${1:+=$1}#nixos" --accept-flake-config --impure
+      # Resolve the nix-config flake path: main worktree by default,
+      # or the gwq worktree for <branch> when given
+      _nixcfg_flake() {
+          if [[ -z "$1" ]]; then
+              echo "$NIXCFG_DIR"
+          else
+              gwq get -g "nix-config:$1"
+          fi
       }
 
-      # Usage: drs [branch]  (branch -> nix-config=<branch> worktree)
+      # Usage: nrs [branch]  (branch -> nix-config=<branch> gwq worktree)
+      nrs() {
+          local dir
+          dir=$(_nixcfg_flake "$1") || return 1
+          sudo nixos-rebuild switch --flake "$dir#nixos" --accept-flake-config --impure
+      }
+
+      # Usage: drs [branch]  (branch -> nix-config=<branch> gwq worktree)
       drs() {
-          sudo darwin-rebuild switch --flake "$NIXCFG_DIR''${1:+=$1}#mac"
+          local dir
+          dir=$(_nixcfg_flake "$1") || return 1
+          sudo darwin-rebuild switch --flake "$dir#mac"
       }
 
       # Set GitHub Actions secrets


### PR DESCRIPTION
## Summary

`nrs`/`drs` always rebuilt from the main `nix-config` checkout, so testing an unmerged branch required merging it first. This lets `nrs`/`drs` target a gwq worktree by branch name, so unmerged branches can be verified via rebuild before merging.

## Changes

- Convert `nrs`/`drs` from static shell aliases into functions taking an optional `[branch]` argument.
- With no argument, rebuild from `$NIXCFG_DIR` (main worktree) as before.
- With a branch argument, resolve the corresponding gwq worktree path via `gwq get -g "nix-config:<branch>"` and rebuild from there.
- Resolution goes through gwq's own resolver (rather than hand-splicing `=<branch>`) so it correctly handles gwq's `sanitize_chars` for branch names containing `/` or `:`, and fails before `sudo` if the worktree can't be resolved.