### PR TITLE
Add brightness display and controls to Waybar

### DIFF
--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -234,8 +234,8 @@ in
       hl.bind("XF86AudioLowerVolume",  hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"),      { locked = true, repeating = true })
       hl.bind("XF86AudioMute",         hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"),     { locked = true, repeating = true })
       hl.bind("XF86AudioMicMute",      hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"),   { locked = true, repeating = true })
-      hl.bind("XF86MonBrightnessUp",   hl.dsp.exec_cmd("light -A 5"),                                     { locked = true, repeating = true })
-      hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("light -U 5"),                                     { locked = true, repeating = true })
+      hl.bind("XF86MonBrightnessUp",   hl.dsp.exec_cmd("brightnessctl set 5%+"),                          { locked = true, repeating = true })
+      hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("brightnessctl set 5%-"),                          { locked = true, repeating = true })
 
       -- Media control
       hl.bind("XF86AudioNext",  hl.dsp.exec_cmd("playerctl next"),       { locked = true })

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -48,8 +48,8 @@ in
         modules-left = [ "hyprland/workspaces" ];
         modules-center = [ ];
         modules-right = [
-          "group/backlight"
-          "group/pulseaudio"
+          "group/backlight#backlight-group"
+          "group/pulseaudio#pulseaudio-group"
           "clock"
           "network"
           "bluetooth"
@@ -73,7 +73,6 @@ in
             default = icons.volumeLevels;
           };
           scroll-step = 5; # match the 5% step used by the Hyprland volume keybindings
-          on-click-right = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
         };
 
         "pulseaudio/slider" = {
@@ -82,7 +81,7 @@ in
           orientation = "horizontal";
         };
 
-        "group/pulseaudio" = {
+        "group/pulseaudio#pulseaudio-group" = {
           orientation = "horizontal";
           drawer = {
             click-to-reveal = true;
@@ -105,7 +104,7 @@ in
           orientation = "horizontal";
         };
 
-        "group/backlight" = {
+        "group/backlight#backlight-group" = {
           orientation = "horizontal";
           drawer = {
             click-to-reveal = true;

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -48,8 +48,8 @@ in
         modules-left = [ "hyprland/workspaces" ];
         modules-center = [ ];
         modules-right = [
-          "group/backlight#backlight-group"
-          "group/pulseaudio#pulseaudio-group"
+          "group/backlight-drawer"
+          "group/pulseaudio-drawer"
           "clock"
           "network"
           "bluetooth"
@@ -81,7 +81,7 @@ in
           orientation = "horizontal";
         };
 
-        "group/pulseaudio#pulseaudio-group" = {
+        "group/pulseaudio-drawer" = {
           orientation = "horizontal";
           drawer = {
             click-to-reveal = true;
@@ -104,7 +104,7 @@ in
           orientation = "horizontal";
         };
 
-        "group/backlight#backlight-group" = {
+        "group/backlight-drawer" = {
           orientation = "horizontal";
           drawer = {
             click-to-reveal = true;
@@ -188,25 +188,6 @@ in
       #bluetooth:hover,
       #battery:hover {
         opacity: 0.8;
-      }
-
-      /* The group/pulseaudio#pulseaudio-group and group/backlight#backlight-group
-         wrappers reuse the leader module's own #pulseaudio/#backlight id (only
-         the "#..." suffix becomes a class), so the chip rules above also match
-         the wrapper. Reset it there via the class the suffix actually adds,
-         leaving the inner leader module as the only visible chip. */
-      #pulseaudio.pulseaudio-group,
-      #backlight.backlight-group {
-        background-color: transparent;
-        border: none;
-        border-radius: 0;
-        padding: 0;
-        margin: 0;
-      }
-
-      #pulseaudio.pulseaudio-group:hover,
-      #backlight.backlight-group:hover {
-        opacity: 1;
       }
 
       /* Workspaces -- blue, active pink, urgent red */

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -79,8 +79,7 @@ in
         backlight = {
           format = "{icon} {percent}%";
           format-icons = icons.brightnessLevels;
-          on-scroll-up = "brightnessctl set 5%+";
-          on-scroll-down = "brightnessctl set 5%-";
+          scroll-step = 5;
         };
 
         battery = {

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -5,6 +5,9 @@ let
   #     the previously working config (git rev a9e568f).
   #   - pulseaudio icons: extracted byte-for-byte from a verified external
   #     Waybar config (Uliboooo/dotfiles .config/waybar/config.hypr.jsonc).
+  #   - brightness icons: codepoints looked up in the installed
+  #     NotoSansNerdFont-SemiBold.ttf cmap (nerd-fonts.noto), not typed from
+  #     memory, then rendered via `chr()` and byte-verified with `od`.
   icons = {
     clock = ""; # U+F017 nf-fa-clock_o
     batteryLevels = [
@@ -24,6 +27,11 @@ let
       "󰖀"
       "󰕾"
     ]; # U+F057F/F0580/F057E nf-md-volume low/med/high
+    brightnessLevels = [
+      "󰃚"
+      "󰃝"
+      "󰃠"
+    ]; # U+F00DA/F00DD/F00E0 nf-md-brightness_1/4/7 low/mid/high (verified via NotoSansNerdFont-SemiBold.ttf cmap)
   };
 in
 {
@@ -40,6 +48,7 @@ in
         modules-left = [ "hyprland/workspaces" ];
         modules-center = [ ];
         modules-right = [
+          "backlight"
           "pulseaudio"
           "clock"
           "network"
@@ -63,6 +72,15 @@ in
           format-icons = {
             default = icons.volumeLevels;
           };
+          scroll-step = 5; # match the 5% step used by the Hyprland volume keybindings
+          on-click = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+        };
+
+        backlight = {
+          format = "{icon} {percent}%";
+          format-icons = icons.brightnessLevels;
+          on-scroll-up = "brightnessctl set 5%+";
+          on-scroll-down = "brightnessctl set 5%-";
         };
 
         battery = {
@@ -116,6 +134,7 @@ in
 
       #workspaces,
       #clock,
+      #backlight,
       #pulseaudio,
       #network,
       #bluetooth,
@@ -131,6 +150,7 @@ in
 
       #workspaces:hover,
       #clock:hover,
+      #backlight:hover,
       #pulseaudio:hover,
       #network:hover,
       #bluetooth:hover,
@@ -174,6 +194,12 @@ in
         color: #6c7086;
         border-color: #6c7086;
         text-decoration: line-through;
+      }
+
+      /* Backlight -- yellow */
+      #backlight {
+        color: #f9e2af;
+        border: 1px solid #f9e2af;
       }
 
       /* Network -- sky */

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -31,7 +31,7 @@ let
       "󰃚"
       "󰃝"
       "󰃠"
-    ]; # U+F00DA/F00DD/F00E0 nf-md-brightness_1/4/7 low/mid/high (verified via NotoSansNerdFont-SemiBold.ttf cmap)
+    ]; # U+F00DA/F00DD/F00E0 nf-md-brightness_1/4/7 low/mid/high
   };
 in
 {

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -190,6 +190,25 @@ in
         opacity: 0.8;
       }
 
+      /* The group/pulseaudio#pulseaudio-group and group/backlight#backlight-group
+         wrappers reuse the leader module's own #pulseaudio/#backlight id (only
+         the "#..." suffix becomes a class), so the chip rules above also match
+         the wrapper. Reset it there via the class the suffix actually adds,
+         leaving the inner leader module as the only visible chip. */
+      #pulseaudio.pulseaudio-group,
+      #backlight.backlight-group {
+        background-color: transparent;
+        border: none;
+        border-radius: 0;
+        padding: 0;
+        margin: 0;
+      }
+
+      #pulseaudio.pulseaudio-group:hover,
+      #backlight.backlight-group:hover {
+        opacity: 1;
+      }
+
       /* Workspaces -- blue, active pink, urgent red */
       #workspaces {
         color: #89b4fa;

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -49,7 +49,9 @@ in
         modules-center = [ ];
         modules-right = [
           "backlight"
+          "backlight/slider"
           "pulseaudio"
+          "pulseaudio/slider"
           "clock"
           "network"
           "bluetooth"
@@ -76,10 +78,22 @@ in
           on-click = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
         };
 
+        "pulseaudio/slider" = {
+          min = 0;
+          max = 100;
+          orientation = "horizontal";
+        };
+
         backlight = {
           format = "{icon} {percent}%";
           format-icons = icons.brightnessLevels;
           scroll-step = 5;
+        };
+
+        "backlight/slider" = {
+          min = 0;
+          max = 100;
+          orientation = "horizontal";
         };
 
         battery = {
@@ -199,6 +213,39 @@ in
       #backlight {
         color: #f9e2af;
         border: 1px solid #f9e2af;
+      }
+
+      /* Volume/brightness sliders -- Mac-style thin rounded track */
+      #pulseaudio-slider,
+      #backlight-slider {
+        padding: 0 8px;
+        margin: 4px 3px;
+        min-width: 90px;
+      }
+
+      #pulseaudio-slider trough,
+      #backlight-slider trough {
+        min-height: 6px;
+        border-radius: 6px;
+        background-color: rgba(108, 112, 134, 0.5);
+      }
+
+      #pulseaudio-slider highlight {
+        border-radius: 6px;
+        background-color: #a6e3a1;
+      }
+
+      #backlight-slider highlight {
+        border-radius: 6px;
+        background-color: #f9e2af;
+      }
+
+      #pulseaudio-slider slider,
+      #backlight-slider slider {
+        min-width: 12px;
+        min-height: 12px;
+        border-radius: 50%;
+        background-color: #cdd6f4;
       }
 
       /* Network -- sky */

--- a/home/nixos/waybar/default.nix
+++ b/home/nixos/waybar/default.nix
@@ -48,10 +48,8 @@ in
         modules-left = [ "hyprland/workspaces" ];
         modules-center = [ ];
         modules-right = [
-          "backlight"
-          "backlight/slider"
-          "pulseaudio"
-          "pulseaudio/slider"
+          "group/backlight"
+          "group/pulseaudio"
           "clock"
           "network"
           "bluetooth"
@@ -75,13 +73,24 @@ in
             default = icons.volumeLevels;
           };
           scroll-step = 5; # match the 5% step used by the Hyprland volume keybindings
-          on-click = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+          on-click-right = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
         };
 
         "pulseaudio/slider" = {
           min = 0;
           max = 100;
           orientation = "horizontal";
+        };
+
+        "group/pulseaudio" = {
+          orientation = "horizontal";
+          drawer = {
+            click-to-reveal = true;
+          };
+          modules = [
+            "pulseaudio"
+            "pulseaudio/slider"
+          ];
         };
 
         backlight = {
@@ -94,6 +103,17 @@ in
           min = 0;
           max = 100;
           orientation = "horizontal";
+        };
+
+        "group/backlight" = {
+          orientation = "horizontal";
+          drawer = {
+            click-to-reveal = true;
+          };
+          modules = [
+            "backlight"
+            "backlight/slider"
+          ];
         };
 
         battery = {

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -142,9 +142,8 @@
       alsa.support32Bit = true;
       pulse.enable = true;
     };
-    # Grant the "video" group write access to /sys/class/backlight, so
-    # brightnessctl (and Waybar's backlight module) can adjust brightness
-    # without root.
+    # brightnessctl's udev rules grant the "video" group write access to
+    # /sys/class/backlight, so brightness can be adjusted without root.
     udev.packages = [ pkgs.brightnessctl ];
   };
 

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -142,6 +142,10 @@
       alsa.support32Bit = true;
       pulse.enable = true;
     };
+    # Grant the "video" group write access to /sys/class/backlight, so
+    # brightnessctl (and Waybar's backlight module) can adjust brightness
+    # without root.
+    udev.packages = [ pkgs.brightnessctl ];
   };
 
   security = {


### PR DESCRIPTION
## Summary

Waybar showed volume but not brightness, and neither was truly adjustable from the bar. This adds a brightness display to Waybar and makes both volume and brightness adjustable with a Mac-style click-to-reveal slider, fixing the underlying permission gap that would have made brightness adjustment silently no-op.

## Changes

- Grant the "video" group write access to `/sys/class/backlight` via `services.udev.packages = [ pkgs.brightnessctl ];`, required for any non-root brightness adjustment to actually work.
- Add a native Waybar `backlight` module showing brightness percent, adjustable via `scroll-step` (matching the existing `pulseaudio` module's pattern). Brightness icon codepoints were looked up in the installed Nerd Font's cmap and byte-verified with `od`, not typed from memory.
- Fix the Hyprland `XF86MonBrightnessUp/Down` keybindings, which called an uninstalled `light` binary and never worked, to use `brightnessctl` instead.
- Add `pulseaudio/slider` and `backlight/slider` modules, wrapped in a `group` with `drawer.click-to-reveal`, so clicking the volume/brightness icon reveals a draggable Mac-style slider instead of always showing it.
  - Waybar's click-to-reveal only intercepts the left mouse button, but a leader module with *any* `on-click`-family action swallows every click before it can bubble up to the group (confirmed in Waybar's `AModule::handleUserEvent`, which unconditionally returns `true`). This is why the volume icon's mute-toggle-on-click was dropped — the two features can't coexist on the same leader module. Mute is still available via the existing `XF86AudioMute` keybinding.
  - The group wrapper reuses the leader module's own CSS id unless given a name that doesn't collide with any real module (Waybar's `group/<name>#<id>` ref parsing does no validation against module types), so the groups are named `group/pulseaudio-drawer` / `group/backlight-drawer` rather than `group/pulseaudio` / `group/backlight`.

## Related Issue

None.
