### PR TITLE
Set Claude Code response language to Japanese

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -23,6 +23,7 @@ in
     settings = {
       model = "opusplan";
       advisorModel = "opus";
+      language = "japanese";
       alwaysThinkingEnabled = true;
       statusLine = {
         type = "command";


### PR DESCRIPTION
## Summary

Claude Code の応答言語を日本語に固定する。

## Changes

- `profiles/home/claude/default.nix` の `settings` に `language = "japanese";` を追加し、`~/.claude/settings.json` に `"language": "japanese"` を出力するようにした