### PR TITLE
:rotating_light: Update fzf options to use new home-manager naming

### DIFF
--- a/profiles/home/fzf/default.nix
+++ b/profiles/home/fzf/default.nix
@@ -8,7 +8,7 @@
 
     # Use fd for fast file search (respects .gitignore)
     defaultCommand = "fd --type f --hidden --exclude .git";
-    fileWidgetCommand = "fd --type f --hidden --exclude .git";
-    changeDirWidgetCommand = "fd --type d --hidden --exclude .git";
+    fileWidget.command = "fd --type f --hidden --exclude .git";
+    changeDirWidget.command = "fd --type d --hidden --exclude .git";
   };
 }


### PR DESCRIPTION
## Summary

`drs`（darwin-rebuild switch）実行時に home-manager から出ていた option rename の警告を解消する。

## Changes

- `profiles/home/fzf/default.nix` の `fileWidgetCommand` / `changeDirWidgetCommand` を、home-manager がリネームした新しい属性名 `fileWidget.command` / `changeDirWidget.command` に更新