### PR TITLE
Set DP-1 monitor scale to 1.25 and 60Hz

### DIFF
--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -44,7 +44,7 @@ in
       ------------------
       ---- MONITORS ----
       ------------------
-      hl.monitor({ output = "DP-1", mode = "preferred", position = "0x0", scale = "1" })
+      hl.monitor({ output = "DP-1", mode = "3840x2160@60", position = "0x0", scale = "1.25" })
       hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto-center-down", scale = "1" })
 
       ---------------------


### PR DESCRIPTION
## Summary

Fix external monitor (DP-1, 4K TV) text readability by adjusting Hyprland monitor scaling. Previously DP-1 ran at scale 1.0 with `mode = preferred`, which resolved to 3840x2160@30Hz — text was too small and refresh rate was low.

## Changes

- `home/nixos/hyprland/default.nix`: DP-1 monitor set to `mode = "3840x2160@60"` and `scale = "1.25"` (effective resolution 3072x1728, 60Hz refresh rate)