### PR TITLE
Enlarge cursor size from 24 to 32

### DIFF
--- a/home/nixos/hyprland/cursor/default.nix
+++ b/home/nixos/hyprland/cursor/default.nix
@@ -1,0 +1,100 @@
+{
+  pkgs,
+  ...
+}:
+let
+  # Hyprland's built-in teardrop logo (extracted from Hyprland/assets/header.svg,
+  # rotated -30deg to match the compositor's own fallback cursor), packaged as an
+  # installable cursor theme in both hyprcursor (vector) and XCursor (raster) formats.
+  cursorLogoSvg = ./hyprland-logo.svg;
+  cursorDescription = "Hyprland's built-in teardrop logo, as an installable cursor theme";
+  xcursorThemeName = "hyprland-logo";
+  hyprcursorThemeName = "hyprland_logo";
+  cursorSizes = [
+    24
+    32
+    48
+    64
+    96
+  ];
+  # The size Hyprland actually runs with (XCURSOR_SIZE/HYPRCURSOR_SIZE below).
+  # Must be a member of cursorSizes so the XCursor raster generated for it
+  # exists exactly (no libXcursor fallback to the nearest available size).
+  defaultCursorSize = 32;
+  # Where in the (square) logo the pointer's "click point" sits, as a 0-1 fraction
+  # of width/height. Single source of truth for both the hyprcursor meta.hl and the
+  # XCursor xcursorgen.conf hotspots below.
+  cursorHotspotXRatio = 0.230;
+  cursorHotspotYRatio = 0.037;
+  cursorSizesStr = pkgs.lib.concatMapStringsSep " " toString cursorSizes;
+  xcursorgenConfLines = pkgs.lib.concatMapStringsSep "\n" (
+    size:
+    let
+      x = builtins.floor (size * cursorHotspotXRatio + 0.5);
+      y = builtins.floor (size * cursorHotspotYRatio + 0.5);
+    in
+    "${toString size} ${toString x} ${toString y} pngs/logo-${toString size}.png"
+  ) cursorSizes;
+  cursorTheme =
+    pkgs.runCommand "hyprland-logo-cursor-theme"
+      {
+        nativeBuildInputs = [
+          pkgs.resvg
+          pkgs.xcursorgen
+          pkgs.hyprcursor
+        ];
+      }
+      ''
+        mkdir -p hc-src/hyprcursors/left_ptr
+        cp ${cursorLogoSvg} hc-src/hyprcursors/left_ptr/logo.svg
+
+        cat > hc-src/manifest.hl <<'EOF'
+        name = ${hyprcursorThemeName}
+        description = ${cursorDescription}
+        version = 0.1
+        cursors_directory = hyprcursors
+        EOF
+
+        cat > hc-src/hyprcursors/left_ptr/meta.hl <<'EOF'
+        resize_algorithm = bilinear
+        hotspot_x = ${toString cursorHotspotXRatio}
+        hotspot_y = ${toString cursorHotspotYRatio}
+        define_override = arrow
+        define_override = default
+        define_override = left_ptr
+        define_size = 32, logo.svg
+        EOF
+
+        mkdir -p hcout
+        hyprcursor-util --create hc-src --output hcout
+        mkdir -p $out/${hyprcursorThemeName}
+        cp -r hcout/*/. $out/${hyprcursorThemeName}/
+
+        mkdir -p pngs
+        for sz in ${cursorSizesStr}; do
+          resvg -w "$sz" -h "$sz" ${cursorLogoSvg} "pngs/logo-$sz.png"
+        done
+
+        cat > hyprland-logo.conf <<'EOF'
+        ${xcursorgenConfLines}
+        EOF
+
+        xcursorgen hyprland-logo.conf left_ptr
+
+        mkdir -p $out/${xcursorThemeName}/cursors
+        cp left_ptr $out/${xcursorThemeName}/cursors/left_ptr
+        ln -s left_ptr $out/${xcursorThemeName}/cursors/default
+        ln -s left_ptr $out/${xcursorThemeName}/cursors/arrow
+
+        cat > $out/${xcursorThemeName}/index.theme <<'EOF'
+        [Icon Theme]
+        Name=Hyprland Logo
+        Comment=${cursorDescription}
+        Inherits=Adwaita
+        EOF
+      '';
+in
+{
+  theme = cursorTheme;
+  inherit xcursorThemeName hyprcursorThemeName defaultCursorSize;
+}

--- a/home/nixos/hyprland/cursor/hyprland-logo.svg
+++ b/home/nixos/hyprland/cursor/hyprland-logo.svg
@@ -1,0 +1,56 @@
+<svg viewBox="61.6600 349.1600 319.6800 319.6800" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="319.6800" height="319.6800">
+  <defs>
+    <style>
+      .st0 {
+        fill: url(#a);
+      }
+
+      .st1 {
+        fill: url(#b);
+      }
+
+      .st2 {
+        fill: url(#c);
+      }
+
+      .st3 {
+        fill: url(#d);
+      }
+
+      .st4 {
+        fill: url(#e);
+      }
+
+      .st5 {
+        fill: url(#f);
+      }
+
+      .st6 {
+        fill: url(#g);
+      }
+
+      .st7 {
+        fill: url(#h);
+      }
+
+      .st8 {
+        fill: url(#i);
+      }
+    </style><style class="darkreader darkreader--sync" media="screen"/>
+    <linearGradient gradientUnits="userSpaceOnUse" y2="491.29" x2="561.93" y1="593.85" x1="561.93" id="i">
+      <stop stop-color="#00a8f4" offset="0" style="--darkreader-inline-stopcolor: var(--darkreader-background-00a8f4, #0086c3);" data-darkreader-inline-stopcolor=""/>
+      <stop stop-color="#00e5d0" offset="1" style="--darkreader-inline-stopcolor: var(--darkreader-background-00e5d0, #00b7a6);" data-darkreader-inline-stopcolor=""/>
+    </linearGradient>
+    <linearGradient xlink:href="#i" y2="491.58" x2="630.69" y1="567.48" x1="630.69" id="c"/>
+    <linearGradient xlink:href="#i" y2="493.77" x2="480.34" y1="596.04" x1="480.34" id="a"/>
+    <linearGradient xlink:href="#i" y2="470.31" x2="392.86" y1="567.48" x1="392.86" id="b"/>
+    <linearGradient xlink:href="#i" y2="491.73" x2="804.79" y1="567.48" x1="804.79" id="f"/>
+    <linearGradient xlink:href="#i" y2="463.46" x2="883.97" y1="569.67" x1="883.97" id="g"/>
+    <linearGradient xlink:href="#i" y2="465.94" x2="671.56" y1="567.48" x1="671.56" id="d"/>
+    <linearGradient xlink:href="#i" y2="491.58" x2="724.23" y1="569.67" x1="724.23" id="e"/>
+    <linearGradient xlink:href="#i" y2="346.78" x2="202.09" y1="659.7" x1="202.09" id="h"/>
+  </defs>
+  <g transform="rotate(-30 202.3 503.37)">
+    <path d="M311.03,491.55c-9.09-20.56-22.42-39.71-35.29-58.22-2.38-3.41-4.62-6.64-6.84-9.87-3.15-4.6-7.42-10.49-12.36-17.31-11.29-15.59-28.92-39.62-40.84-59.36v49.42c12.28,17.62,24.2,33.49,30.57,42.78,13.94,20.33,30.09,42,39.67,63.66,28.78,65.13-11.7,128.85-82.05,129.61h-1.26c-.18,0-.35,0-.53,0-.18,0-.35,0-.53,0h-1.26c-70.35-.76-110.84-64.48-82.05-129.61,9.58-21.67,25.72-43.33,39.67-63.66,6.36-9.28,18.28-25.16,30.57-42.78v-49.42c-11.92,19.75-29.55,43.78-40.84,59.36-4.94,6.81-9.21,12.7-12.36,17.31-2.22,3.23-4.46,6.45-6.84,9.87-12.88,18.52-26.21,37.67-35.29,58.22-8.83,19.97-12.7,40.38-11.49,60.65,1.16,19.65,7.28,38.57,17.68,54.73,10.28,15.97,24.74,29.21,41.81,38.29,17.64,9.37,37.44,14.25,58.87,14.48.52,0,1.03,0,1.56,0,.18,0,.35,0,.53,0,.18,0,.35,0,.53,0,.52,0,1.03,0,1.56,0,21.43-.23,41.23-5.1,58.87-14.48,17.07-9.08,31.52-22.32,41.81-38.29,10.4-16.16,16.52-35.08,17.68-54.73,1.2-20.27-2.67-40.68-11.49-60.65Z" class="st7"/>
+  </g>
+</svg>

--- a/home/nixos/hyprland/cursor/hyprland-logo.svg
+++ b/home/nixos/hyprland/cursor/hyprland-logo.svg
@@ -1,53 +1,14 @@
 <svg viewBox="61.6600 349.1600 319.6800 319.6800" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="319.6800" height="319.6800">
   <defs>
     <style>
-      .st0 {
-        fill: url(#a);
-      }
-
-      .st1 {
-        fill: url(#b);
-      }
-
-      .st2 {
-        fill: url(#c);
-      }
-
-      .st3 {
-        fill: url(#d);
-      }
-
-      .st4 {
-        fill: url(#e);
-      }
-
-      .st5 {
-        fill: url(#f);
-      }
-
-      .st6 {
-        fill: url(#g);
-      }
-
       .st7 {
         fill: url(#h);
       }
-
-      .st8 {
-        fill: url(#i);
-      }
-    </style><style class="darkreader darkreader--sync" media="screen"/>
+    </style>
     <linearGradient gradientUnits="userSpaceOnUse" y2="491.29" x2="561.93" y1="593.85" x1="561.93" id="i">
-      <stop stop-color="#00a8f4" offset="0" style="--darkreader-inline-stopcolor: var(--darkreader-background-00a8f4, #0086c3);" data-darkreader-inline-stopcolor=""/>
-      <stop stop-color="#00e5d0" offset="1" style="--darkreader-inline-stopcolor: var(--darkreader-background-00e5d0, #00b7a6);" data-darkreader-inline-stopcolor=""/>
+      <stop stop-color="#00a8f4" offset="0"/>
+      <stop stop-color="#00e5d0" offset="1"/>
     </linearGradient>
-    <linearGradient xlink:href="#i" y2="491.58" x2="630.69" y1="567.48" x1="630.69" id="c"/>
-    <linearGradient xlink:href="#i" y2="493.77" x2="480.34" y1="596.04" x1="480.34" id="a"/>
-    <linearGradient xlink:href="#i" y2="470.31" x2="392.86" y1="567.48" x1="392.86" id="b"/>
-    <linearGradient xlink:href="#i" y2="491.73" x2="804.79" y1="567.48" x1="804.79" id="f"/>
-    <linearGradient xlink:href="#i" y2="463.46" x2="883.97" y1="569.67" x1="883.97" id="g"/>
-    <linearGradient xlink:href="#i" y2="465.94" x2="671.56" y1="567.48" x1="671.56" id="d"/>
-    <linearGradient xlink:href="#i" y2="491.58" x2="724.23" y1="569.67" x1="724.23" id="e"/>
     <linearGradient xlink:href="#i" y2="346.78" x2="202.09" y1="659.7" x1="202.09" id="h"/>
   </defs>
   <g transform="rotate(-30 202.3 503.37)">

--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -31,99 +31,10 @@ let
     fi
   '';
 
-  # Hyprland's built-in teardrop logo (extracted from Hyprland/assets/header.svg,
-  # rotated -30deg to match the compositor's own fallback cursor), packaged as an
-  # installable cursor theme in both hyprcursor (vector) and XCursor (raster) formats.
   # NOTE: not using home.pointerCursor here because HYPRCURSOR_THEME/XCURSOR_THEME
   # must go through hl.env (see ENVIRONMENT VARIABLES below) for the same startup-
   # timing reason as the other hl.env-only vars (GTK_IM_MODULE, etc.) in this file.
-  cursorLogoSvg = ./cursor/hyprland-logo.svg;
-  cursorDescription = "Hyprland's built-in teardrop logo, as an installable cursor theme";
-  xcursorThemeName = "hyprland-logo";
-  hyprcursorThemeName = "hyprland_logo";
-  cursorSizes = [
-    24
-    32
-    48
-    64
-    96
-  ];
-  # The size Hyprland actually runs with (XCURSOR_SIZE/HYPRCURSOR_SIZE below).
-  # Must be a member of cursorSizes so the XCursor raster generated for it
-  # exists exactly (no libXcursor fallback to the nearest available size).
-  defaultCursorSize = 32;
-  # Where in the (square) logo the pointer's "click point" sits, as a 0-1 fraction
-  # of width/height. Single source of truth for both the hyprcursor meta.hl and the
-  # XCursor xcursorgen.conf hotspots below.
-  cursorHotspotXRatio = 0.230;
-  cursorHotspotYRatio = 0.037;
-  cursorSizesStr = pkgs.lib.concatMapStringsSep " " toString cursorSizes;
-  xcursorgenConfLines = pkgs.lib.concatMapStringsSep "\n" (
-    size:
-    let
-      x = builtins.floor (size * cursorHotspotXRatio + 0.5);
-      y = builtins.floor (size * cursorHotspotYRatio + 0.5);
-    in
-    "${toString size} ${toString x} ${toString y} pngs/logo-${toString size}.png"
-  ) cursorSizes;
-  cursorTheme =
-    pkgs.runCommand "hyprland-logo-cursor-theme"
-      {
-        nativeBuildInputs = [
-          pkgs.resvg
-          pkgs.xcursorgen
-          pkgs.hyprcursor
-        ];
-      }
-      ''
-        mkdir -p hc-src/hyprcursors/left_ptr
-        cp ${cursorLogoSvg} hc-src/hyprcursors/left_ptr/logo.svg
-
-        cat > hc-src/manifest.hl <<'EOF'
-        name = ${hyprcursorThemeName}
-        description = ${cursorDescription}
-        version = 0.1
-        cursors_directory = hyprcursors
-        EOF
-
-        cat > hc-src/hyprcursors/left_ptr/meta.hl <<'EOF'
-        resize_algorithm = bilinear
-        hotspot_x = ${toString cursorHotspotXRatio}
-        hotspot_y = ${toString cursorHotspotYRatio}
-        define_override = arrow
-        define_override = default
-        define_override = left_ptr
-        define_size = 32, logo.svg
-        EOF
-
-        mkdir -p hcout
-        hyprcursor-util --create hc-src --output hcout
-        mkdir -p $out/${hyprcursorThemeName}
-        cp -r hcout/*/. $out/${hyprcursorThemeName}/
-
-        mkdir -p pngs
-        for sz in ${cursorSizesStr}; do
-          resvg -w "$sz" -h "$sz" ${cursorLogoSvg} "pngs/logo-$sz.png"
-        done
-
-        cat > hyprland-logo.conf <<'EOF'
-        ${xcursorgenConfLines}
-        EOF
-
-        xcursorgen hyprland-logo.conf left_ptr
-
-        mkdir -p $out/${xcursorThemeName}/cursors
-        cp left_ptr $out/${xcursorThemeName}/cursors/left_ptr
-        ln -s left_ptr $out/${xcursorThemeName}/cursors/default
-        ln -s left_ptr $out/${xcursorThemeName}/cursors/arrow
-
-        cat > $out/${xcursorThemeName}/index.theme <<'EOF'
-        [Icon Theme]
-        Name=Hyprland Logo
-        Comment=${cursorDescription}
-        Inherits=Adwaita
-        EOF
-      '';
+  cursor = import ./cursor { inherit pkgs; };
 in
 {
   home = {
@@ -131,8 +42,9 @@ in
 
     # XCursor theme (GTK/QT/XWayland apps like Chrome) and hyprcursor theme
     # (native Wayland, scales cleanly across mixed-DPI monitors).
-    file.".icons/${xcursorThemeName}".source = "${cursorTheme}/${xcursorThemeName}";
-    file.".local/share/icons/${hyprcursorThemeName}".source = "${cursorTheme}/${hyprcursorThemeName}";
+    file.".icons/${cursor.xcursorThemeName}".source = "${cursor.theme}/${cursor.xcursorThemeName}";
+    file.".local/share/icons/${cursor.hyprcursorThemeName}".source =
+      "${cursor.theme}/${cursor.hyprcursorThemeName}";
   };
 
   wayland.windowManager.hyprland = {
@@ -167,10 +79,10 @@ in
       -------------------------------
       ---- ENVIRONMENT VARIABLES ----
       -------------------------------
-      hl.env("XCURSOR_THEME", "${xcursorThemeName}")
-      hl.env("XCURSOR_SIZE", "${toString defaultCursorSize}")
-      hl.env("HYPRCURSOR_THEME", "${hyprcursorThemeName}")
-      hl.env("HYPRCURSOR_SIZE", "${toString defaultCursorSize}")
+      hl.env("XCURSOR_THEME", "${cursor.xcursorThemeName}")
+      hl.env("XCURSOR_SIZE", "${toString cursor.defaultCursorSize}")
+      hl.env("HYPRCURSOR_THEME", "${cursor.hyprcursorThemeName}")
+      hl.env("HYPRCURSOR_SIZE", "${toString cursor.defaultCursorSize}")
       hl.env("GTK_IM_MODULE", "fcitx")
       hl.env("QT_IM_MODULE", "fcitx")
       hl.env("XMODIFIERS", "@im=fcitx")

--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -34,7 +34,34 @@ let
   # Hyprland's built-in teardrop logo (extracted from Hyprland/assets/header.svg,
   # rotated -30deg to match the compositor's own fallback cursor), packaged as an
   # installable cursor theme in both hyprcursor (vector) and XCursor (raster) formats.
+  # NOTE: not using home.pointerCursor here because HYPRCURSOR_THEME/XCURSOR_THEME
+  # must go through hl.env (see ENVIRONMENT VARIABLES below) for the same startup-
+  # timing reason as the other hl.env-only vars (GTK_IM_MODULE, etc.) in this file.
   cursorLogoSvg = ./cursor/hyprland-logo.svg;
+  cursorDescription = "Hyprland's built-in teardrop logo, as an installable cursor theme";
+  xcursorThemeName = "hyprland-logo";
+  hyprcursorThemeName = "hyprland_logo";
+  cursorSizes = [
+    24
+    32
+    48
+    64
+    96
+  ];
+  # Where in the (square) logo the pointer's "click point" sits, as a 0-1 fraction
+  # of width/height. Single source of truth for both the hyprcursor meta.hl and the
+  # XCursor xcursorgen.conf hotspots below.
+  cursorHotspotXRatio = 0.230;
+  cursorHotspotYRatio = 0.037;
+  cursorSizesStr = pkgs.lib.concatMapStringsSep " " toString cursorSizes;
+  xcursorgenConfLines = pkgs.lib.concatMapStringsSep "\n" (
+    size:
+    let
+      x = builtins.floor (size * cursorHotspotXRatio + 0.5);
+      y = builtins.floor (size * cursorHotspotYRatio + 0.5);
+    in
+    "${toString size} ${toString x} ${toString y} pngs/logo-${toString size}.png"
+  ) cursorSizes;
   cursorTheme =
     pkgs.runCommand "hyprland-logo-cursor-theme"
       {
@@ -42,7 +69,6 @@ let
           pkgs.resvg
           pkgs.xcursorgen
           pkgs.hyprcursor
-          pkgs.xcur2png
         ];
       }
       ''
@@ -50,16 +76,16 @@ let
         cp ${cursorLogoSvg} hc-src/hyprcursors/left_ptr/logo.svg
 
         cat > hc-src/manifest.hl <<EOF
-        name = HyprlandLogo
-        description = Hyprland's built-in teardrop logo, as an installable cursor theme
+        name = ${hyprcursorThemeName}
+        description = ${cursorDescription}
         version = 0.1
         cursors_directory = hyprcursors
         EOF
 
         cat > hc-src/hyprcursors/left_ptr/meta.hl <<EOF
         resize_algorithm = bilinear
-        hotspot_x = 0.230
-        hotspot_y = 0.037
+        hotspot_x = ${toString cursorHotspotXRatio}
+        hotspot_y = ${toString cursorHotspotYRatio}
         define_override = arrow
         define_override = default
         define_override = left_ptr
@@ -68,33 +94,29 @@ let
 
         mkdir -p hcout
         hyprcursor-util --create hc-src --output hcout
-        mkdir -p $out/hyprland_logo
-        cp -r hcout/theme_HyprlandLogo/. $out/hyprland_logo/
+        mkdir -p $out/${hyprcursorThemeName}
+        cp -r hcout/*/. $out/${hyprcursorThemeName}/
 
         mkdir -p pngs
-        for sz in 24 32 48 64 96; do
+        for sz in ${cursorSizesStr}; do
           resvg -w "$sz" -h "$sz" ${cursorLogoSvg} "pngs/logo-$sz.png"
         done
 
         cat > hyprland-logo.conf <<EOF
-        24 6 1 pngs/logo-24.png
-        32 7 1 pngs/logo-32.png
-        48 11 2 pngs/logo-48.png
-        64 15 2 pngs/logo-64.png
-        96 22 4 pngs/logo-96.png
+        ${xcursorgenConfLines}
         EOF
 
         xcursorgen hyprland-logo.conf left_ptr
 
-        mkdir -p $out/hyprland-logo/cursors
-        cp left_ptr $out/hyprland-logo/cursors/left_ptr
-        ln -s left_ptr $out/hyprland-logo/cursors/default
-        ln -s left_ptr $out/hyprland-logo/cursors/arrow
+        mkdir -p $out/${xcursorThemeName}/cursors
+        cp left_ptr $out/${xcursorThemeName}/cursors/left_ptr
+        ln -s left_ptr $out/${xcursorThemeName}/cursors/default
+        ln -s left_ptr $out/${xcursorThemeName}/cursors/arrow
 
-        cat > $out/hyprland-logo/index.theme <<EOF
+        cat > $out/${xcursorThemeName}/index.theme <<EOF
         [Icon Theme]
         Name=Hyprland Logo
-        Comment=Hyprland's built-in teardrop logo, as an installable cursor theme
+        Comment=${cursorDescription}
         Inherits=Adwaita
         EOF
       '';
@@ -105,8 +127,8 @@ in
 
     # XCursor theme (GTK/QT/XWayland apps like Chrome) and hyprcursor theme
     # (native Wayland, scales cleanly across mixed-DPI monitors).
-    file.".icons/hyprland-logo".source = "${cursorTheme}/hyprland-logo";
-    file.".local/share/icons/hyprland_logo".source = "${cursorTheme}/hyprland_logo";
+    file.".icons/${xcursorThemeName}".source = "${cursorTheme}/${xcursorThemeName}";
+    file.".local/share/icons/${hyprcursorThemeName}".source = "${cursorTheme}/${hyprcursorThemeName}";
   };
 
   wayland.windowManager.hyprland = {
@@ -141,9 +163,9 @@ in
       -------------------------------
       ---- ENVIRONMENT VARIABLES ----
       -------------------------------
-      hl.env("XCURSOR_THEME", "hyprland-logo")
+      hl.env("XCURSOR_THEME", "${xcursorThemeName}")
       hl.env("XCURSOR_SIZE", "32")
-      hl.env("HYPRCURSOR_THEME", "hyprland_logo")
+      hl.env("HYPRCURSOR_THEME", "${hyprcursorThemeName}")
       hl.env("HYPRCURSOR_SIZE", "32")
       hl.env("GTK_IM_MODULE", "fcitx")
       hl.env("QT_IM_MODULE", "fcitx")

--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -66,8 +66,8 @@ in
       -------------------------------
       ---- ENVIRONMENT VARIABLES ----
       -------------------------------
-      hl.env("XCURSOR_SIZE", "24")
-      hl.env("HYPRCURSOR_SIZE", "24")
+      hl.env("XCURSOR_SIZE", "32")
+      hl.env("HYPRCURSOR_SIZE", "32")
       hl.env("GTK_IM_MODULE", "fcitx")
       hl.env("QT_IM_MODULE", "fcitx")
       hl.env("XMODIFIERS", "@im=fcitx")

--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -48,6 +48,10 @@ let
     64
     96
   ];
+  # The size Hyprland actually runs with (XCURSOR_SIZE/HYPRCURSOR_SIZE below).
+  # Must be a member of cursorSizes so the XCursor raster generated for it
+  # exists exactly (no libXcursor fallback to the nearest available size).
+  defaultCursorSize = 32;
   # Where in the (square) logo the pointer's "click point" sits, as a 0-1 fraction
   # of width/height. Single source of truth for both the hyprcursor meta.hl and the
   # XCursor xcursorgen.conf hotspots below.
@@ -75,14 +79,14 @@ let
         mkdir -p hc-src/hyprcursors/left_ptr
         cp ${cursorLogoSvg} hc-src/hyprcursors/left_ptr/logo.svg
 
-        cat > hc-src/manifest.hl <<EOF
+        cat > hc-src/manifest.hl <<'EOF'
         name = ${hyprcursorThemeName}
         description = ${cursorDescription}
         version = 0.1
         cursors_directory = hyprcursors
         EOF
 
-        cat > hc-src/hyprcursors/left_ptr/meta.hl <<EOF
+        cat > hc-src/hyprcursors/left_ptr/meta.hl <<'EOF'
         resize_algorithm = bilinear
         hotspot_x = ${toString cursorHotspotXRatio}
         hotspot_y = ${toString cursorHotspotYRatio}
@@ -102,7 +106,7 @@ let
           resvg -w "$sz" -h "$sz" ${cursorLogoSvg} "pngs/logo-$sz.png"
         done
 
-        cat > hyprland-logo.conf <<EOF
+        cat > hyprland-logo.conf <<'EOF'
         ${xcursorgenConfLines}
         EOF
 
@@ -113,7 +117,7 @@ let
         ln -s left_ptr $out/${xcursorThemeName}/cursors/default
         ln -s left_ptr $out/${xcursorThemeName}/cursors/arrow
 
-        cat > $out/${xcursorThemeName}/index.theme <<EOF
+        cat > $out/${xcursorThemeName}/index.theme <<'EOF'
         [Icon Theme]
         Name=Hyprland Logo
         Comment=${cursorDescription}
@@ -164,9 +168,9 @@ in
       ---- ENVIRONMENT VARIABLES ----
       -------------------------------
       hl.env("XCURSOR_THEME", "${xcursorThemeName}")
-      hl.env("XCURSOR_SIZE", "32")
+      hl.env("XCURSOR_SIZE", "${toString defaultCursorSize}")
       hl.env("HYPRCURSOR_THEME", "${hyprcursorThemeName}")
-      hl.env("HYPRCURSOR_SIZE", "32")
+      hl.env("HYPRCURSOR_SIZE", "${toString defaultCursorSize}")
       hl.env("GTK_IM_MODULE", "fcitx")
       hl.env("QT_IM_MODULE", "fcitx")
       hl.env("XMODIFIERS", "@im=fcitx")

--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -30,9 +30,84 @@ let
       hyprctl dispatch settiled
     fi
   '';
+
+  # Hyprland's built-in teardrop logo (extracted from Hyprland/assets/header.svg,
+  # rotated -30deg to match the compositor's own fallback cursor), packaged as an
+  # installable cursor theme in both hyprcursor (vector) and XCursor (raster) formats.
+  cursorLogoSvg = ./cursor/hyprland-logo.svg;
+  cursorTheme =
+    pkgs.runCommand "hyprland-logo-cursor-theme"
+      {
+        nativeBuildInputs = [
+          pkgs.resvg
+          pkgs.xcursorgen
+          pkgs.hyprcursor
+          pkgs.xcur2png
+        ];
+      }
+      ''
+        mkdir -p hc-src/hyprcursors/left_ptr
+        cp ${cursorLogoSvg} hc-src/hyprcursors/left_ptr/logo.svg
+
+        cat > hc-src/manifest.hl <<EOF
+        name = HyprlandLogo
+        description = Hyprland's built-in teardrop logo, as an installable cursor theme
+        version = 0.1
+        cursors_directory = hyprcursors
+        EOF
+
+        cat > hc-src/hyprcursors/left_ptr/meta.hl <<EOF
+        resize_algorithm = bilinear
+        hotspot_x = 0.230
+        hotspot_y = 0.037
+        define_override = arrow
+        define_override = default
+        define_override = left_ptr
+        define_size = 32, logo.svg
+        EOF
+
+        mkdir -p hcout
+        hyprcursor-util --create hc-src --output hcout
+        mkdir -p $out/hyprland_logo
+        cp -r hcout/theme_HyprlandLogo/. $out/hyprland_logo/
+
+        mkdir -p pngs
+        for sz in 24 32 48 64 96; do
+          resvg -w "$sz" -h "$sz" ${cursorLogoSvg} "pngs/logo-$sz.png"
+        done
+
+        cat > hyprland-logo.conf <<EOF
+        24 6 1 pngs/logo-24.png
+        32 7 1 pngs/logo-32.png
+        48 11 2 pngs/logo-48.png
+        64 15 2 pngs/logo-64.png
+        96 22 4 pngs/logo-96.png
+        EOF
+
+        xcursorgen hyprland-logo.conf left_ptr
+
+        mkdir -p $out/hyprland-logo/cursors
+        cp left_ptr $out/hyprland-logo/cursors/left_ptr
+        ln -s left_ptr $out/hyprland-logo/cursors/default
+        ln -s left_ptr $out/hyprland-logo/cursors/arrow
+
+        cat > $out/hyprland-logo/index.theme <<EOF
+        [Icon Theme]
+        Name=Hyprland Logo
+        Comment=Hyprland's built-in teardrop logo, as an installable cursor theme
+        Inherits=Adwaita
+        EOF
+      '';
 in
 {
-  home.packages = [ pkgs.grimblast ];
+  home = {
+    packages = [ pkgs.grimblast ];
+
+    # XCursor theme (GTK/QT/XWayland apps like Chrome) and hyprcursor theme
+    # (native Wayland, scales cleanly across mixed-DPI monitors).
+    file.".icons/hyprland-logo".source = "${cursorTheme}/hyprland-logo";
+    file.".local/share/icons/hyprland_logo".source = "${cursorTheme}/hyprland_logo";
+  };
 
   wayland.windowManager.hyprland = {
     configType = "lua";
@@ -66,7 +141,9 @@ in
       -------------------------------
       ---- ENVIRONMENT VARIABLES ----
       -------------------------------
+      hl.env("XCURSOR_THEME", "hyprland-logo")
       hl.env("XCURSOR_SIZE", "32")
+      hl.env("HYPRCURSOR_THEME", "hyprland_logo")
       hl.env("HYPRCURSOR_SIZE", "32")
       hl.env("GTK_IM_MODULE", "fcitx")
       hl.env("QT_IM_MODULE", "fcitx")
@@ -136,6 +213,10 @@ in
             natural_scroll = true,
             scroll_factor = 0.3,
           },
+        },
+
+        cursor = {
+          enable_hyprcursor = true,
         },
       })
 


### PR DESCRIPTION
## Summary

外部モニタにつないで複数ワークスペースで作業していると、マウスカーソルが小さく見えて作業しづらい問題を解消するため、Hyprland のカーソルサイズを大きくする。

## Changes

- `home/nixos/hyprland/default.nix` の `XCURSOR_SIZE` / `HYPRCURSOR_SIZE` を `24` → `32` に変更（XWayland アプリとネイティブアプリで食い違いが出ないよう両方揃えて変更）