### PR TITLE
Add addyosmani/agent-skills plugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "agent-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783029904,
+        "narHash": "sha256-S0rqJjcyC6MQo4pYLHws1jZXgr7Knqbyv+u95mg9cUE=",
+        "owner": "addyosmani",
+        "repo": "agent-skills",
+        "rev": "8c6530305396f341b5da7201cf1f7e390fdb863f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "addyosmani",
+        "repo": "agent-skills",
+        "type": "github"
+      }
+    },
     "cl-nix-lite": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -393,6 +409,7 @@
     },
     "root": {
       "inputs": {
+        "agent-skills": "agent-skills",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    agent-skills = {
+      url = "github:addyosmani/agent-skills";
+      flake = false;
+    };
   };
 
   outputs =

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -106,6 +106,7 @@ in
     context = ./CLAUDE.md;
     agentsDir = ./agents;
     skills = ./skills;
+    plugins = [ inputs.agent-skills ];
   };
 
   home.file =


### PR DESCRIPTION
## Summary

Pin [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) as a flake input and wire it into `programs.claude-code.plugins` so the user-level `claude` (`~/.claude/`) loads it as a Claude Code plugin.

The upstream repo is a full Claude Code plugin (`plugin.json` / `.claude-plugin/`), not just a bag of skills: its 24 `skills/<name>/SKILL.md` files reference companion checklists under a repo-root `references/` directory. Taking only the `skills/` subtree would break those references, so this loads the plugin as a whole via `programs.claude-code.plugins`, which passes `--plugin-dir <store-path>` to the `claude` wrapper. Verified end-to-end by building the NixOS toplevel and inspecting the generated wrapper — it correctly resolves `--plugin-dir` to the `agent-skills` store path, with `skills/`, `references/`, `commands/`, `agents/`, and `hooks/` all present underneath.

## Changes

- `flake.nix`: add `agent-skills` input (`flake = false`, not vendored)
- `flake.lock`: lock the new input
- `profiles/home/claude/default.nix`: add `plugins = [ inputs.agent-skills ];` to `programs.claude-code` (existing local `skills = ./skills;` is untouched)

## Related Issue

None