### PR TITLE
Add ponytail Claude Code plugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -391,6 +391,22 @@
         "type": "github"
       }
     },
+    "ponytail": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782948630,
+        "narHash": "sha256-Pn6gPg0luOO0/I3dP4DzdvFn4Z7rjrK4Bbxf+4VBiYo=",
+        "owner": "DietrichGebert",
+        "repo": "ponytail",
+        "rev": "40e50d9e03242aa5dd53ac771950f9127362b25f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DietrichGebert",
+        "repo": "ponytail",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -402,6 +418,7 @@
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_6",
         "nixpkgs-master": "nixpkgs-master",
+        "ponytail": "ponytail",
         "treefmt-nix": "treefmt-nix_3"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    ponytail = {
+      url = "github:DietrichGebert/ponytail";
+      flake = false;
+    };
   };
 
   outputs =

--- a/overlays/claude-code.nix
+++ b/overlays/claude-code.nix
@@ -1,7 +1,7 @@
 # nixpkgs-master から claude-code を取得するオーバーレイ
 # inputs は flakes/lib/hosts.nix から渡される
 { inputs, system }:
-_: _:
+final: _:
 let
   pkgsMaster = import inputs.nixpkgs-master {
     inherit system;
@@ -10,4 +10,16 @@ let
 in
 {
   inherit (pkgsMaster) claude-code;
+
+  # Some Claude Code plugins (e.g. ponytail) shell out to `node` in their
+  # hooks. Wrap it separately so plain `claude-code` (used as a system
+  # package) doesn't gain a global `node` dependency.
+  claude-code-with-node = final.symlinkJoin {
+    name = "claude-code-with-node";
+    paths = [ final.claude-code ];
+    nativeBuildInputs = [ final.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/claude --prefix PATH : ${final.lib.makeBinPath [ final.nodejs ]}
+    '';
+  };
 }

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -2,7 +2,6 @@
   inputs,
   system,
   pkgs,
-  lib,
   ...
 }:
 let
@@ -19,15 +18,9 @@ in
   programs.claude-code = {
     enable = true;
 
-    # ponytail's hooks invoke `node`; keep it on Claude's PATH only, not global.
-    package = pkgs.symlinkJoin {
-      name = "claude-code-with-node";
-      paths = [ pkgs.claude-code ];
-      nativeBuildInputs = [ pkgs.makeWrapper ];
-      postBuild = ''
-        wrapProgram $out/bin/claude --prefix PATH : ${lib.makeBinPath [ pkgs.nodejs ]}
-      '';
-    };
+    # ponytail's hooks invoke `node`; claude-code-with-node keeps it off the
+    # global PATH (plain claude-code is still used as a system package).
+    package = pkgs.claude-code-with-node;
 
     plugins = [ inputs.ponytail ];
 

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -1,4 +1,10 @@
-{ inputs, system, ... }:
+{
+  inputs,
+  system,
+  pkgs,
+  lib,
+  ...
+}:
 let
   mcpPkgs = import inputs.mcp-servers-nix.inputs.nixpkgs { inherit system; };
 in
@@ -12,6 +18,18 @@ in
 
   programs.claude-code = {
     enable = true;
+
+    # ponytail's hooks invoke `node`; keep it on Claude's PATH only, not global.
+    package = pkgs.symlinkJoin {
+      name = "claude-code-with-node";
+      paths = [ pkgs.claude-code ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/claude --prefix PATH : ${lib.makeBinPath [ pkgs.nodejs ]}
+      '';
+    };
+
+    plugins = [ inputs.ponytail ];
 
     mcpServers = {
       nixos = {


### PR DESCRIPTION
## Summary

Adds the [ponytail](https://github.com/DietrichGebert/ponytail) Claude Code plugin at the user level, declaratively via Nix so it stays reproducible and doesn't rely on the interactive `/plugin marketplace add` / `/plugin install` flow (which isn't compatible with a Nix-managed `~/.claude`).

## Changes

- `flake.nix`: add `ponytail` as a `flake = false` input, pinned via `flake.lock`.
- `profiles/home/claude/default.nix`:
  - Load ponytail through `programs.claude-code.plugins` (home-manager wraps `claude` with `--plugin-dir <path>`).
  - ponytail's hooks invoke `node`; instead of adding `nodejs` globally, wrap the `claude` binary itself (`symlinkJoin` + `makeWrapper`) so `node` is only on Claude's PATH.

Verified with `nix flake check`, building `programs.claude-code.finalPackage`, and inspecting/running the resulting wrapper chain (`--plugin-dir` points at ponytail's source, and the inner wrapper prepends `nodejs` to `PATH`).