### PR TITLE
Add gwq-prune to clean up worktrees with gone upstream

### DIFF
--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -109,6 +109,47 @@ _: {
       }
       zle -N ghq-fzf
       bindkey '^g' ghq-fzf
+
+      # Prune gwq worktrees whose upstream branch is gone from the remote,
+      # like `git fetch --prune`. Also deletes the local branch.
+      # Usage: gwq-prune [--dry-run]
+      gwq-prune() {
+          git fetch --prune || return 1
+
+          local -a gone
+          gone=(''${(@f)$(git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads/ \
+              | awk '$2 == "[gone]" { print $1 }')})
+
+          if (( ''${#gone} == 0 )); then
+              echo "gwq-prune: no worktrees to prune"
+              return 0
+          fi
+
+          local -a wt targets
+          wt=(''${(@f)$(gwq list --json | jq -r '.[] | select(.is_main == false) | .branch')})
+
+          local current b
+          current=$(git symbolic-ref --quiet --short HEAD)
+          targets=(''${''${gone:*wt}:#''${(b)current}})
+
+          if (( ''${#targets} == 0 )); then
+              echo "gwq-prune: no worktrees to prune"
+              return 0
+          fi
+
+          echo "gwq-prune: worktrees with gone upstream:"
+          printf '  %s\n' $targets
+          [[ "$1" == "--dry-run" ]] && return 0
+
+          printf 'Remove these worktrees and local branches? [y/N] '
+          local ans
+          read -r ans
+          [[ "$ans" == [yY]* ]] || { echo "gwq-prune: aborted"; return 1; }
+
+          for b in $targets; do
+              gwq remove -b --force-delete-branch "$b"
+          done
+      }
     '';
     prezto = {
       enable = true;

--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -130,7 +130,7 @@ _: {
 
           local current b
           current=$(git symbolic-ref --quiet --short HEAD)
-          targets=(''${''${gone:*wt}:#''${(b)current}})
+          targets=(''${''${gone:*wt}:#$current})
 
           if (( ''${#targets} == 0 )); then
               echo "gwq-prune: no worktrees to prune"
@@ -141,14 +141,22 @@ _: {
           printf '  %s\n' $targets
           [[ "$1" == "--dry-run" ]] && return 0
 
+          [[ -t 0 ]] || { echo "gwq-prune: not running interactively, aborting" >&2; return 1; }
           printf 'Remove these worktrees and local branches? [y/N] '
           local ans
           read -r ans
           [[ "$ans" == [yY]* ]] || { echo "gwq-prune: aborted"; return 1; }
 
+          local -a failed
           for b in $targets; do
-              gwq remove -b --force-delete-branch "$b"
+              gwq remove -b --force-delete-branch "$b" || failed+=("$b")
           done
+
+          if (( ''${#failed} > 0 )); then
+              echo "gwq-prune: failed to remove: ''${(j:, :)failed}" >&2
+              return 1
+          fi
+          echo "gwq-prune: removed ''${#targets} worktree(s)"
       }
     '';
     prezto = {


### PR DESCRIPTION
## Summary

Adds a `gwq-prune` zsh function that, like `git fetch --prune` for remote-tracking refs, cleans up local `gwq` worktrees whose upstream branch has been deleted from the remote (merged/closed PRs). Also deletes the corresponding local branch.

## Changes

- `profiles/home/zsh/default.nix`: add `gwq-prune` function
  - `git fetch --prune`, then intersects local branches with `[gone]` upstream tracking against `gwq`-managed worktree branches (excluding the main worktree and the currently checked-out branch)
  - Prints the target list; supports `--dry-run` to preview only
  - Prompts `[y/N]` before removing, with a TTY guard so a non-interactive invocation aborts instead of silently reading unrelated stdin as confirmation
  - Removes each target via `gwq remove -b --force-delete-branch`, tracking per-branch failures and printing a summary instead of silently swallowing errors

## Related Issue

None