### PR TITLE
Add SilentSDDM display manager theme

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,7 +436,28 @@
         "nixpkgs": "nixpkgs_6",
         "nixpkgs-master": "nixpkgs-master",
         "ponytail": "ponytail",
+        "silentSDDM": "silentSDDM",
         "treefmt-nix": "treefmt-nix_3"
+      }
+    },
+    "silentSDDM": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782837720,
+        "narHash": "sha256-6t35AM4lhK7kQTH103YMICyHzMofZMgs+xIJ9kgMZ4I=",
+        "owner": "uiriansan",
+        "repo": "SilentSDDM",
+        "rev": "3b55533612bc66a225b8babc6abfc5f24d04f4ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "uiriansan",
+        "repo": "SilentSDDM",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    silentSDDM = {
+      url = "github:uiriansan/SilentSDDM";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     agent-skills = {
       url = "github:addyosmani/agent-skills";
       flake = false;

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -1,10 +1,12 @@
 {
+  inputs,
   pkgs,
   ...
 }:
 {
   imports = [
     ../../profiles/hosts/packages.nix
+    inputs.silentSDDM.nixosModules.default
   ];
 
   fonts = {
@@ -166,6 +168,10 @@
     hyprland = {
       enable = true;
       xwayland.enable = true;
+    };
+    silentSDDM = {
+      enable = true;
+      theme = "default";
     };
     zsh.enable = true;
     nix-ld = {


### PR DESCRIPTION
## Summary

NixOS ホスト (`nixos`) にディスプレイマネージャとして [SilentSDDM](https://github.com/uiriansan/SilentSDDM)（Qt6 のモダンな SDDM テーマ）の `default` プリセットを導入。これまで DM は未設定（GDM は明示的に無効化済み）で、Hyprland を TTY から手動起動していた。

## Changes

- `flake.nix`: `silentSDDM` flake input を追加（`nixpkgs.follows = "nixpkgs"`）
- `hosts/nixos/configuration.nix`:
  - `inputs.silentSDDM.nixosModules.default` を import
  - `programs.silentSDDM = { enable = true; theme = "default"; }` を設定
  - module が `services.displayManager.sddm`（有効化・Qt6 パッケージ・extraPackages・greeter 環境）を自動設定
- `flake.lock`: 新 input の反映

`services.xserver.enable = true` を維持しているため SDDM は X greeter で起動する（module が `wayland.enable = !xserver.enable` を条件付けしているため）。Hyprland は wayland セッションとしてログイン後に起動する。

ライセンスは GPLv3（free）で、flake input として参照するのみのため追加の Nix 設定は不要。

## Related Issue

なし