### PR TITLE
Downgrade ANTHROPIC_DEFAULT_OPUS_MODEL to claude-opus-4-7

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -9,7 +9,7 @@ let
 in
 {
   home.sessionVariables = {
-    ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-8";
+    ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-7";
     ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-5";
     ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";


### PR DESCRIPTION
## Summary

`ANTHROPIC_DEFAULT_OPUS_MODEL` を `claude-opus-4-8` から `claude-opus-4-7` にダウングレードします。

## Changes

- `profiles/home/claude/default.nix`: `ANTHROPIC_DEFAULT_OPUS_MODEL` を `claude-opus-4-7` に変更