### PR TITLE
:zap: Reduce idle battery drain on nixos host (Phase 1)

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -67,7 +67,7 @@
   networking = {
     hostName = "nixos";
     networkmanager.enable = true;
-    networkmanager.wifi.powersave = false;
+    networkmanager.wifi.powersave = true;
   };
 
   hardware.bluetooth = {

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -136,6 +136,7 @@
       enable = true; # local DNS cache via stub resolver (127.0.0.53)
       settings.Resolve.LLMNR = "false"; # disable LLMNR to prevent link-local name poisoning
     };
+    power-profiles-daemon.enable = true;
     printing.enable = true;
     pulseaudio.enable = false;
     pipewire = {

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -72,7 +72,7 @@
 
   hardware.bluetooth = {
     enable = true;
-    powerOnBoot = true;
+    powerOnBoot = false;
   };
 
   users = {


### PR DESCRIPTION
## Summary

nixos ホスト（AMD Ryzen 7 7735U）のアイドル時バッテリー消費が実測 15.6W と、同等機種の期待値 4〜8W の約 2 倍だった。原因は電源管理フレームワークが未導入で、かつ Wi-Fi / Bluetooth の省電力が明示的に無効化されていたこと。

副作用が読みやすい 3 点のみを Phase 1 として先に投入し、実機で削減幅を確認する。hypridle 導入や Docker autostart 停止などは効果が大きい一方でサスペンド挙動の検証が必要なため、別 PR に切り出す。

## Changes

- `services.power-profiles-daemon.enable = true;` を追加（`amd_pstate=active` と親和性が高く、EPP / platform_profile を統合管理。`powerprofilesctl` で切替可能）
- `networking.networkmanager.wifi.powersave` を `false` → `true` に変更（Wi-Fi モジュール常時アクティブによる 1〜3W の損失を削減）
- `hardware.bluetooth.powerOnBoot` を `true` → `false` に変更（未使用時も起動時から Bluetooth ラジオが ON になっていたのを解消。`enable` は維持し、必要時は `bluetoothctl power on` で有効化）

## Related Issue

Closes #105