### PR TITLE
Ignore lid switch on AC power

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -137,6 +137,11 @@
       settings.Resolve.LLMNR = "false"; # disable LLMNR to prevent link-local name poisoning
     };
     power-profiles-daemon.enable = true;
+    # Ignore lid close on AC power; battery keeps the systemd default (suspend).
+    logind.settings.Login = {
+      HandleLidSwitchExternalPower = "ignore";
+      HandleLidSwitchDocked = "ignore";
+    };
     printing.enable = true;
     pulseaudio.enable = false;
     pipewire = {


### PR DESCRIPTION
## Summary

Keep the NixOS laptop running when the lid is closed while connected to AC power, so long-running tasks (builds, downloads) survive clamshell. On battery power, the lid still suspends as usual (systemd default).

## Changes

- Add `services.logind.settings.Login` in `hosts/nixos/configuration.nix`:
  - `HandleLidSwitchExternalPower = "ignore"` — ignore lid close on AC power
  - `HandleLidSwitchDocked = "ignore"` — ignore lid close when docked