### PR TITLE
Remap Caps Lock to Escape via keyd on NixOS

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -132,6 +132,13 @@
         variant = "";
       };
     };
+    keyd = {
+      enable = true;
+      keyboards.default = {
+        ids = [ "*" ];
+        settings.main.capslock = "esc";
+      };
+    };
     resolved = {
       enable = true; # local DNS cache via stub resolver (127.0.0.53)
       settings.Resolve.LLMNR = "false"; # disable LLMNR to prevent link-local name poisoning


### PR DESCRIPTION
## Summary

NixOS ホストで Caps Lock を Escape として機能させる。`services.keyd` を用い、evdev レイヤで一箇所だけ設定することで Hyprland (Wayland)・SDDM・TTY のすべてのセッションに remap を反映させる。

## Changes

- `hosts/nixos/configuration.nix`: `services.keyd` を追加し、全キーボード (`ids = [ "*" ]`) の Caps Lock を Escape として扱う設定を有効化