### PR TITLE
:sparkles: Add OCaml support to nvim flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.nvim == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/nvim/nix/pkgs/vim-plugins/default.nix
+++ b/nvim/nix/pkgs/vim-plugins/default.nix
@@ -205,6 +205,8 @@ with pkgs.vimPlugins;
       lua
       markdown
       nix
+      ocaml
+      ocaml_interface
       prisma
       purescript
       rust

--- a/nvim/nix/tools.nix
+++ b/nvim/nix/tools.nix
@@ -18,6 +18,7 @@ let
     deno
     gopls
     lua-language-server
+    ocamlPackages.ocaml-lsp
     prisma-language-server
     ps-pkgs.purescript-language-server
     ruff
@@ -39,7 +40,10 @@ let
       shfmt.package
       terraform.package
     ])
-    ++ [ ps-pkgs.purs-tidy ];
+    ++ [
+      ps-pkgs.purs-tidy
+      pkgs.ocamlPackages.ocamlformat
+    ];
 
   linters = with pkgs; [
     actionlint

--- a/nvim/nvim/lua/plugins/conform.lua
+++ b/nvim/nvim/lua/plugins/conform.lua
@@ -20,6 +20,7 @@ return {
 				bash = { "shfmt" },
 				zsh = { "shfmt" },
 				nix = { "nixfmt" },
+				ocaml = { "ocamlformat" },
 				rust = { "rustfmt" },
 				purescript = { "purs_tidy" },
 				python = { "ruff_format", "ruff_organize_imports" },

--- a/nvim/nvim/lua/plugins/lsp.lua
+++ b/nvim/nvim/lua/plugins/lsp.lua
@@ -52,6 +52,7 @@ return {
 			vim.lsp.config.gopls = {}
 			vim.lsp.config.hls = {}
 			vim.lsp.config.lua_ls = {}
+			vim.lsp.config.ocamllsp = {}
 			vim.lsp.config.prismals = {}
 			vim.lsp.config.purescriptls = {}
 			vim.lsp.config.rust_analyzer = {
@@ -77,6 +78,7 @@ return {
 				"gopls",
 				"hls",
 				"lua_ls",
+				"ocamllsp",
 				"prismals",
 				"purescriptls",
 				"rust_analyzer",


### PR DESCRIPTION
## Summary

Neovim flake (`nvim/`) に OCaml 用の LSP・treesitter・formatter サポートを追加。既存の Rust など他言語と同じパターンで実装。

## Changes

- `nix/tools.nix`: `ocamlPackages.ocaml-lsp` (LSP) と `ocamlPackages.ocamlformat` (formatter) を追加
- `nvim/lua/plugins/lsp.lua`: `vim.lsp.config.ocamllsp` を定義し `vim.lsp.enable` に追加
- `nix/pkgs/vim-plugins/default.nix`: treesitter parser に `ocaml` / `ocaml_interface` (`.mli` 用) を追加
- `nvim/lua/plugins/conform.lua`: `ocaml = { "ocamlformat" }` を追加

## Verification

- `nix fmt` / `nix flake check` / `nix build` すべて通過
- ビルド済み wrapper を実際に headless nvim で起動し、`.ml` ファイルを開いて以下を確認:
  - `ocamllsp` が LSP クライアントとしてアタッチ
  - treesitter parser `ocaml` が有効化
  - conform 経由で ocamlformat が正しく整形 (`let  greet name =` → `let greet name = ...`)