### PR TITLE
Hide broken uwsm-managed Hyprland entry from SDDM

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -1,5 +1,7 @@
 {
+  config,
   inputs,
+  lib,
   pkgs,
   ...
 }:
@@ -176,6 +178,20 @@
     enable = true;
     autoPrune.enable = true;
   };
+
+  # Hide the broken "Hyprland (uwsm-managed)" SDDM entry: nixpkgs' hyprland
+  # package ships hyprland-uwsm.desktop unconditionally, but this repo never
+  # enables programs.uwsm, so selecting it freezes the greeter.
+  services.displayManager.sessionPackages = lib.mkForce [
+    (pkgs.symlinkJoin {
+      name = "hyprland-session-no-uwsm";
+      paths = [ config.programs.hyprland.package ];
+      postBuild = ''
+        rm -f $out/share/wayland-sessions/hyprland-uwsm.desktop
+      '';
+      passthru.providedSessions = [ "hyprland" ];
+    })
+  ];
 
   programs = {
     hyprland = {


### PR DESCRIPTION
## Summary

SDDM greeter でセッションとして「Hyprland (uwsm-managed)」を選び Login を押すと、画面が切り替わらず入力も受け付けなくなる不具合を修正する。

nixpkgs の `hyprland` パッケージは `hyprland-uwsm.desktop` を無条件に同梱しているが、この repo は `programs.uwsm` / `programs.hyprland.withUWSM` をどこでも有効化していない。そのため greeter でこのエントリを選ぶと `uwsm start` が NixOS 側の uwsm 統合 (systemd user unit テンプレート等) を欠いたまま起動を試み、セッション準備待ちで固まる。

silentSDDM の module/theme、SDDM 本体 (`HideSessions=` 相当) いずれにもセッションを名前で非表示にするオプションが無いことを確認した上で、session file 自体を greeter に流し込まないようにする方式を採った。

## Changes

- `hosts/nixos/configuration.nix`: `services.displayManager.sessionPackages` を `lib.mkForce` で上書きし、Hyprland パッケージから `hyprland-uwsm.desktop` を除いた `symlinkJoin` ラッパーを登録
- 既存の `home/nixos/hyprland/default.nix` の autostart 設定 (`hl.on("hyprland.start", ...)`, `systemd.enable = true`) は変更なし

## Verification

- `nix build .#nixosConfigurations.nixos.config.system.build.toplevel` — 成功
- 生成された `services.displayManager.sessionData.desktops` store path 配下に `hyprland.desktop` のみ存在し `hyprland-uwsm.desktop` が消えていることを確認
- `nix flake check` / `nix fmt` 全通過
- 実機での SDDM greeter 表示確認と rebuild は `sudo` が必要なためユーザー側で実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)