### PR TITLE
Set Claude Code auto mode as default

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -83,6 +83,7 @@ in
         ];
       };
       permissions = {
+        defaultMode = "auto";
         allow = [
           "Skill(commit)"
           "Skill(pr)"


### PR DESCRIPTION
## Summary

Claude Code の permission mode (`permissions.defaultMode`) をデフォルトで `auto` に設定した。

## Changes

- `profiles/home/claude/default.nix` の `programs.claude-code.settings.permissions` に `defaultMode = "auto";` を追加