### PR TITLE
Move init-env alias to gawakawa/flake-templates

### DIFF
--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -12,7 +12,7 @@ _: {
       ls = "eza -a";
       find = "fd";
       grep = "rg";
-      init-env = "nix run github:gawakawa/init-env";
+      init-env = "nix run github:gawakawa/flake-templates#init-env";
       non-nix-nvim = "XDG_CONFIG_HOME=$HOME/projects/github.com/gawakawa/non-nix-nvim XDG_DATA_HOME=$HOME/.local/share/non-nix-nvim XDG_STATE_HOME=$HOME/.local/state/non-nix-nvim nix run 'nixpkgs#neovim' --";
     };
     initContent = ''


### PR DESCRIPTION
## Summary

`init-env` は `gawakawa/init-env` から `gawakawa/flake-templates` に統合された（`flake-templates` 側に `apps.init-env` として追加）ため、zsh の `init-env` エイリアスの参照先を新しい URL に更新する。

## Changes

- `profiles/home/zsh/default.nix`: `init-env` エイリアスを `nix run github:gawakawa/init-env` から `nix run github:gawakawa/flake-templates#init-env` に変更