### PR TITLE
Add nh clean for user profiles, keep nix.gc for system

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -56,11 +56,6 @@
       ];
       experimental-features = "nix-command flakes";
     };
-    gc = {
-      automatic = true;
-      dates = "monthly";
-      options = "--delete-older-than 30d";
-    };
     optimise = {
       automatic = true;
     };
@@ -208,6 +203,14 @@
       libraries = with pkgs; [
         deno
       ];
+    };
+    nh = {
+      enable = true;
+      clean = {
+        enable = true;
+        dates = "weekly";
+        extraArgs = "--keep-since 30d --keep 3";
+      };
     };
   };
 

--- a/profiles/home/nh/default.nix
+++ b/profiles/home/nh/default.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+{
+  programs.nh = {
+    enable = true;
+    flake = "${config.home.homeDirectory}/projects/github.com/gawakawa/nix-config";
+    clean = {
+      enable = true;
+      dates = "weekly";
+      extraArgs = "--keep-since 30d --keep 3";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

[nh](https://github.com/viperML/nh) (Nix helper) の `programs.nh.clean` を使い、ユーザプロファイルの自動クリーンアップを導入する。参考: https://zenn.dev/trifolium/articles/ed53f1a6ebbbf8

nix-darwin には `programs.nh` モジュールが存在しないため、Darwin のシステムプロファイル自動 GC は既存の `nix.gc.automatic` をそのまま残す。役割分担は以下の通り:

| | システムプロファイル | ユーザプロファイル |
|---|---|---|
| NixOS | `programs.nh.clean` (新規, root, 週次) | `programs.nh.clean` (新規, home-manager, 週次) |
| Darwin | `nix.gc` (既存, 毎日) | `programs.nh.clean` (新規, home-manager, 週次) |

## Changes

- 新規 `profiles/home/nh/default.nix`: home-manager 側で `programs.nh` を有効化 (`enable`, `flake = NH_FLAKE`, `clean.enable/dates/extraArgs`)。`profiles/home/default.nix` の `importSubdirs` により NixOS/Darwin 両方の home-manager に自動で取り込まれる
- `hosts/nixos/configuration.nix`: 既存の `nix.gc`(月次) を削除し、system-level の `programs.nh.clean` (週次) に置き換え
- `hosts/mac/configuration.nix`: 変更なし。nh に system-level のクリーンアップ手段が無いため既存 `nix.gc.automatic` を維持
- 保持ポリシーは両レイヤ共通で `--keep-since 30d --keep 3`

## Related Issue

なし