### PR TITLE
Fix init-env alias glob expansion

### DIFF
--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -12,7 +12,7 @@ _: {
       ls = "eza -a";
       find = "fd";
       grep = "rg";
-      init-env = "nix run github:gawakawa/flake-templates#init-env";
+      init-env = "nix run \"github:gawakawa/flake-templates#init-env\"";
       non-nix-nvim = "XDG_CONFIG_HOME=$HOME/projects/github.com/gawakawa/non-nix-nvim XDG_DATA_HOME=$HOME/.local/share/non-nix-nvim XDG_STATE_HOME=$HOME/.local/state/non-nix-nvim nix run 'nixpkgs#neovim' --";
     };
     initContent = ''


### PR DESCRIPTION
## Summary

`init-env` alias が zsh 上で `no matches found: github:gawakawa/flake-templates#init-env` エラーになる問題を修正する。

## Changes

- `profiles/home/zsh/default.nix` の `init-env` alias で flake ref をダブルクォート
  - 未クォートの `#init-env` が zsh の `extendedglob`（`#` を繰り返し演算子として解釈）に引っかかり glob 展開エラーになっていた
  - 同ファイル内の `nrs`/`drs`/`flake-init` は同様の `#` を含む flake ref を既にクォート済みで、この alias だけ抜けていた

## Related Issue

なし