### PR TITLE
Preserve version/meta in claude-code-with-node overlay

### DIFF
--- a/overlays/claude-code.nix
+++ b/overlays/claude-code.nix
@@ -15,11 +15,15 @@ in
   # hooks. Wrap it separately so plain `claude-code` (used as a system
   # package) doesn't gain a global `node` dependency.
   claude-code-with-node = final.symlinkJoin {
-    name = "claude-code-with-node";
+    name = "claude-code-with-node-${final.claude-code.version}";
     paths = [ final.claude-code ];
     nativeBuildInputs = [ final.makeWrapper ];
     postBuild = ''
       wrapProgram $out/bin/claude --prefix PATH : ${final.lib.makeBinPath [ final.nodejs ]}
     '';
+    # Preserve version/meta so Home Manager's programs.claude-code module can
+    # detect the version and use persistent personal plugins instead of the
+    # legacy --plugin-dir wrapper.
+    inherit (final.claude-code) version meta;
   };
 }


### PR DESCRIPTION
## Summary

`nix flake check` / build 時に次の evaluation warning が出ていた:

> `programs.claude-code.package` has no detectable version and uses the legacy `--plugin-dir` wrapper. Strict-parser subcommands such as `claude rc` may reject managed MCP, LSP, or plugin arguments. Upgrade Claude Code to version 2.1.157 or later to use persistent personal plugins instead.

`overlays/claude-code.nix` の `claude-code-with-node` (`symlinkJoin` によるラッパー派生) が `version`/`meta` を継承していなかったため、Home Manager の `programs.claude-code` モジュールが `lib.getVersion` でバージョンを検出できず、legacy `--plugin-dir` ラッパーにフォールバックしていた。上流の `claude-code` (nixpkgs-master) は既に `2.1.211` で `2.1.157` を超えており、パッケージ自体のアップグレードは不要。

## Changes

- `overlays/claude-code.nix`: `claude-code-with-node` に `inherit (final.claude-code) version meta;` を追加し、`name` にも version を付与。これにより `lib.getVersion` が正しくバージョンを検出し、Home Manager が personal plugin 方式 (`~/.claude/skills/<name>` への symlink) を使うようになる。

## Related Issue

なし