### PR TITLE
Stop auto-starting chrome at Hyprland startup

### DIFF
--- a/home/nixos/hyprland/default.nix
+++ b/home/nixos/hyprland/default.nix
@@ -72,7 +72,6 @@ in
       hl.on("hyprland.start", function()
         hl.exec_cmd("fcitx5 -d")
         hl.exec_cmd("waybar")
-        hl.exec_cmd("google-chrome-stable")
         hl.exec_cmd("${launchWezterm}")
       end)
 


### PR DESCRIPTION
## Summary

Hyprland 起動時に chrome と wezterm が両方自動起動していたが、wezterm のみが起動するように変更する。

## Changes

- `home/nixos/hyprland/default.nix` の autostart ブロックから `hl.exec_cmd("google-chrome-stable")` を削除
- `SUPER + B` での chrome 手動起動キーバインドは維持
- google-chrome パッケージのインストールは維持