### PR TITLE
Remove Planning section from user-scope CLAUDE.md

### DIFF
--- a/profiles/home/claude/CLAUDE.md
+++ b/profiles/home/claude/CLAUDE.md
@@ -16,11 +16,6 @@ Never jump to solutions before understanding the problem.
 
 - Use the `/commit` skill for commits, `/pr` skill for pull requests.
 
-## Planning
-
-- Split work into tasks small enough to revert cleanly if needed, and track progress with the task tool.
-- Commit each completed task with the `/commit` skill.
-
 ## Code Style
 
 - Write comments in English, only when the code isn't self-explanatory.


### PR DESCRIPTION
## Summary

Removed the `## Planning` section from the user-scope `CLAUDE.md` (`profiles/home/claude/CLAUDE.md`), which always loads into context. Planning workflow guidance is now delegated to the existing `agent-skills:planning-and-task-breakdown` plugin skill instead of being inlined here — no local `## Skills` reference section was added, since skill discovery is already handled by Claude Code's skill listing.

## Changes

- Removed the `## Planning` section (5 lines: task-splitting + task-tool tracking + per-task `/commit` instructions) from `profiles/home/claude/CLAUDE.md`
- No other CLAUDE.md sections changed