### PR TITLE
Bump Claude Code opus default to Opus 5

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -9,9 +9,10 @@ let
 in
 {
   home.sessionVariables = {
-    ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-7";
+    ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-5";
     ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-5";
     ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
+    ANTHROPIC_DEFAULT_FABLE_MODEL = "claude-fable-5";
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
   };
 


### PR DESCRIPTION
## Summary

Bumps the Claude Code `opus` model alias default from Opus 4.7 to Opus 5, and pins the `fable` alias explicitly for future manual use.

## Changes

- `ANTHROPIC_DEFAULT_OPUS_MODEL`: `claude-opus-4-7` → `claude-opus-5`
- Add `ANTHROPIC_DEFAULT_FABLE_MODEL = "claude-fable-5"` (for manual `/model fable` switching; symmetric with the existing opus/sonnet/haiku pins)
- `advisorModel` is left as `"opus"` — it now resolves to Opus 5 automatically. Fable 5 is not yet offered as an advisor by Anthropic (server-side rollout gate), so `advisorModel = "fable"` would silently disable the advisor.

## Related Issue

None