### PR TITLE
Fix UserPromptSubmit hook node-not-found error

### DIFF
--- a/profiles/hosts/packages.nix
+++ b/profiles/hosts/packages.nix
@@ -28,7 +28,6 @@
     fastfetch
     rlwrap
     codex
-    claude-code
     tdf
     xdg-user-dirs
   ];


### PR DESCRIPTION
## Summary

Claude Code の起動ごとに `UserPromptSubmit hook error: /bin/sh: line 1: node: command not found` が発生していた問題を修正する。

原因は、システムワイドにインストールされていた plain `claude-code` パッケージ (`profiles/hosts/packages.nix`) が PATH で Home Manager 側の `claude-code-with-node` ラッパー（`node` を PATH に含める）より優先されていたこと。これにより ponytail プラグインの `UserPromptSubmit` フックが shell out する `node` が見つからず失敗していた。

## Changes

- `profiles/hosts/packages.nix` からシステムワイドの `claude-code` パッケージを削除。`claude` コマンドは Home Manager が提供する `claude-code-with-node` からのみ利用可能になり、`node` が確実に PATH に乗る。