### PR TITLE
Set advisor model to fable

### DIFF
--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -32,7 +32,7 @@ in
 
     settings = {
       model = "opusplan";
-      advisorModel = "opus";
+      advisorModel = "fable";
       language = "japanese";
       alwaysThinkingEnabled = true;
       statusLine = {


### PR DESCRIPTION
## Summary

Set the `advisor` tool's model to `fable` instead of `opus`.

## Changes

- `profiles/home/claude/default.nix`: change `advisorModel` from `"opus"` to `"fable"`