### PR TITLE
Fix UserPromptSubmit hook node: command not found

### DIFF
--- a/overlays/claude-code.nix
+++ b/overlays/claude-code.nix
@@ -1,7 +1,7 @@
 # nixpkgs-master から claude-code を取得するオーバーレイ
 # inputs は flakes/lib/hosts.nix から渡される
 { inputs, system }:
-final: _:
+_: _:
 let
   pkgsMaster = import inputs.nixpkgs-master {
     inherit system;
@@ -10,20 +10,4 @@ let
 in
 {
   inherit (pkgsMaster) claude-code;
-
-  # Some Claude Code plugins (e.g. ponytail) shell out to `node` in their
-  # hooks. Wrap it separately so plain `claude-code` (used as a system
-  # package) doesn't gain a global `node` dependency.
-  claude-code-with-node = final.symlinkJoin {
-    name = "claude-code-with-node-${final.claude-code.version}";
-    paths = [ final.claude-code ];
-    nativeBuildInputs = [ final.makeWrapper ];
-    postBuild = ''
-      wrapProgram $out/bin/claude --prefix PATH : ${final.lib.makeBinPath [ final.nodejs ]}
-    '';
-    # Preserve version/meta so Home Manager's programs.claude-code module can
-    # detect the version and use persistent personal plugins instead of the
-    # legacy --plugin-dir wrapper.
-    inherit (final.claude-code) version meta;
-  };
 }

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -133,9 +133,6 @@ in
     context = ./CLAUDE.md;
     agentsDir = ./agents;
     skills = ./skills;
-    plugins = [
-      inputs.agent-skills
-      inputs.ponytail
-    ];
+    plugins = { inherit (inputs) agent-skills ponytail; };
   };
 }

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -8,20 +8,34 @@ let
   mcpPkgs = import inputs.mcp-servers-nix.inputs.nixpkgs { inherit system; };
 in
 {
-  home.sessionVariables = {
-    ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-5";
-    ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-5";
-    ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
-    ANTHROPIC_DEFAULT_FABLE_MODEL = "claude-fable-5";
-    CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+  home = {
+    sessionVariables = {
+      ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-5";
+      ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-5";
+      ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
+      ANTHROPIC_DEFAULT_FABLE_MODEL = "claude-fable-5";
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+    };
+
+    # ponytail's hooks invoke `node`.
+    packages = [ pkgs.nodejs_24 ];
+
+    file =
+      let
+        scripts = builtins.readDir ./scripts;
+        mkScript = name: {
+          name = ".claude/${name}";
+          value = {
+            source = ./scripts/${name};
+            executable = true;
+          };
+        };
+      in
+      builtins.listToAttrs (map mkScript (builtins.attrNames scripts));
   };
 
   programs.claude-code = {
     enable = true;
-
-    # ponytail's hooks invoke `node`; claude-code-with-node keeps it off the
-    # global PATH (plain claude-code is still used as a system package).
-    package = pkgs.claude-code-with-node;
 
     mcpServers = {
       nixos = {
@@ -124,17 +138,4 @@ in
       inputs.ponytail
     ];
   };
-
-  home.file =
-    let
-      scripts = builtins.readDir ./scripts;
-      mkScript = name: {
-        name = ".claude/${name}";
-        value = {
-          source = ./scripts/${name};
-          executable = true;
-        };
-      };
-    in
-    builtins.listToAttrs (map mkScript (builtins.attrNames scripts));
 }


### PR DESCRIPTION
## Summary

ponytail プラグインの hook (UserPromptSubmit / SessionStart / SubagentStart) が `node` を直接呼ぶが、node を提供していた `claude-code-with-node` wrapper が native installer 版 claude に shadow され起動していなかったため、`node: command not found` が発生していた。

## Changes

- `profiles/home/claude/default.nix`: `home.packages` に `pkgs.nodejs_24` を追加し、`claude-code-with-node` wrapper の使用をやめてデフォルトの `pkgs.claude-code` に戻した。node がどちらの claude 起動経路でも見えるようになる
- `overlays/claude-code.nix`: 不要になった `claude-code-with-node` の定義を削除
- `profiles/home/claude/default.nix`: `programs.claude-code.plugins` をリストから attribute set に変更し、プラグインディレクトリ名がストアパスのハッシュに依存しないよう安定化（`nix flake check` の warning 解消）

## Related Issue

Related to #138 (native installer 版と nix 版の二重管理は別課題として残っている)