### PR TITLE
Fix claude native/nix duplicate management

### DIFF
--- a/profiles/home/zsh/default.nix
+++ b/profiles/home/zsh/default.nix
@@ -17,9 +17,9 @@ _: {
     };
     initContent = ''
       export PATH=$HOME/.deno/bin:$PATH
-      export PATH=$HOME/.local/bin:$PATH
       export PATH=$HOME/.pack/bin:$PATH
       export PATH=$HOME/.ghcup/bin:$PATH
+      export PATH=$PATH:$HOME/.local/bin
       export NIX_PATH=$HOME/.nix-defexpr/channels:$NIX_PATH
 
       mkcd() {


### PR DESCRIPTION
## Summary

`claude` が native installer 版 (`~/.local/bin/claude` → `~/.local/share/claude/versions/`) と nix 版 (`programs.claude-code` 経由) の 2 系統でインストールされており、`profiles/home/zsh/default.nix` が `~/.local/bin` を PATH の先頭に prepend していたため、実際に起動していたのは常に native 版でした。

一方 `~/.claude/` 配下の設定 (settings.json / hooks / skills / agents / plugins) は nix が生成しているため、**バイナリと設定の出所がズレている**状態でした。実害の一例が #139 で修正した UserPromptSubmit hook の `node: command not found` です。

加えて native 版は `~/.claude.json` の `autoUpdates: false` を無視して自己更新しており、3 世代・約 900MB が蓄積していました。

**nix 一本化**を選択しました。逆向き (native 一本化) は不可です — home-manager の `programs.claude-code` は `mcpServers` / `plugins` を設定した状態で `package = null` を禁止する assertion を持つため、バイナリだけ native にして設定生成を nix に任せることはできません。

## Changes

`profiles/home/zsh/default.nix` の `initContent` で `~/.local/bin` を prepend から append に変更 (1 行)。nix 管理のバイナリが手動インストール物に shadow されないようにします。

```diff
-      export PATH=$HOME/.local/bin:$PATH
       export PATH=$HOME/.pack/bin:$PATH
       export PATH=$HOME/.ghcup/bin:$PATH
+      export PATH=$PATH:$HOME/.local/bin
```

repo 外の手動作業として `~/.local/bin/claude` と `~/.local/share/claude` を削除済みです。nix の claude ラッパーは既に `DISABLE_AUTOUPDATER=1` / `DISABLE_INSTALLATION_CHECKS=1` を設定しているため、native 版が再インストール・自己更新で復活することはなく、activation script 等の追加は不要です。

`~/.claude.json` の `installMethod: native` は nix 非管理の state なのでそのまま残しています (`DISABLE_INSTALLATION_CHECKS=1` により無害)。

## 影響範囲

`~/.local/bin` の中身は `als` / `scalafix` / `claude` の 3 つのみで、`als` / `scalafix` は nix profile・`~/.nix-profile/bin`・`/run/current-system/sw/bin` のいずれにも同名バイナリが存在しません。したがって末尾化で解決先が変わるのは `claude` だけです。

また、この PATH 設定は `programs.zsh.initContent` (= `.zshrc`) なので対話 zsh のみに効きます。`home.sessionVariables` に `~/.local/bin` は無いため、systemd ユニットや GUI 起動プロセスは元から影響外です。

## 検証

rebuild 後、クリーンな環境の login zsh で確認済み:

```
PATH 順序:  ... 5:~/.nix-profile/bin  8:/etc/profiles/per-user/iota/bin
            10:/run/current-system/sw/bin  11:~/.local/bin   ← 末尾
which -a claude   → /etc/profiles/per-user/iota/bin/claude   (1 件のみ)
claude --version  → 2.1.224 (Claude Code)
which -a als      → /home/iota/.local/bin/als       (従来通り)
which -a scalafix → /home/iota/.local/bin/scalafix  (従来通り)
```

## Related Issue

Closes #138