### PR TITLE
Manage cloudflare skills plugin via Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,6 +37,22 @@
         "type": "github"
       }
     },
+    "cloudflare": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786124673,
+        "narHash": "sha256-r8HeH9XWV9qhbMq3fPASNfT5Y1mrfsgBI5STiUi/LVA=",
+        "owner": "cloudflare",
+        "repo": "skills",
+        "rev": "f96bff754e428838818017f75817f0f9428acd48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cloudflare",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -426,6 +442,7 @@
     "root": {
       "inputs": {
         "agent-skills": "agent-skills",
+        "cloudflare": "cloudflare",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,11 @@
       url = "github:DietrichGebert/ponytail";
       flake = false;
     };
+
+    cloudflare = {
+      url = "github:cloudflare/skills";
+      flake = false;
+    };
   };
 
   outputs =

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -133,6 +133,6 @@ in
     context = ./CLAUDE.md;
     agentsDir = ./agents;
     skills = ./skills;
-    plugins = { inherit (inputs) agent-skills ponytail; };
+    plugins = { inherit (inputs) agent-skills ponytail cloudflare; };
   };
 }


### PR DESCRIPTION
## Summary

~/.claude/skills/ に自動インストールされた cloudflare skills plugin (13 skills) を、既存の agent-skills/ponytail と同じ方式で flake input + programs.claude-code.plugins に登録し、Nix 管理下に置く。野良ディレクトリは削除済み。

## Changes

- `flake.nix`: `cloudflare` input (`github:cloudflare/skills`, `flake = false`) を追加
- `profiles/home/claude/default.nix`: `programs.claude-code.plugins` に `cloudflare` を追加
- `flake.lock`: 対応するロックエントリを追加