### PR TITLE
Add grilling skill from mattpocock/skills via Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -206,6 +206,22 @@
         "type": "github"
       }
     },
+    "mattpocock-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786045791,
+        "narHash": "sha256-pseSJJb5nBBGPzpxA1GzjGLB9OrT+u0At1saJ4NqZ1E=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "84fdeffd12f2ee307994d1eb6feb48173b6e0502",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "mcp-servers-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_5"
@@ -447,6 +463,7 @@
         "git-hooks-nix": "git-hooks-nix",
         "home-manager": "home-manager",
         "mac-app-util": "mac-app-util",
+        "mattpocock-skills": "mattpocock-skills",
         "mcp-servers-nix": "mcp-servers-nix",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,11 @@
       url = "github:cloudflare/skills";
       flake = false;
     };
+
+    mattpocock-skills = {
+      url = "github:mattpocock/skills";
+      flake = false;
+    };
   };
 
   outputs =

--- a/profiles/home/claude/default.nix
+++ b/profiles/home/claude/default.nix
@@ -31,7 +31,10 @@ in
           };
         };
       in
-      builtins.listToAttrs (map mkScript (builtins.attrNames scripts));
+      builtins.listToAttrs (map mkScript (builtins.attrNames scripts))
+      // {
+        ".claude/skills/grilling".source = "${inputs.mattpocock-skills}/skills/productivity/grilling";
+      };
   };
 
   programs.claude-code = {
@@ -106,6 +109,7 @@ in
           "Skill(skill-creator)"
           "Skill(review-loop)"
           "Skill(japanese-tech-writing)"
+          "Skill(grilling)"
           "mcp__nixos"
         ];
         ask = [


### PR DESCRIPTION
## Summary

mattpocock/skills の grilling スキル（design tree 形式でユーザーを問い詰めるインタビュー手法）を Nix 管理下で導入する。

プラグイン全体（25 スキル）を入れると既存の agent-skills/ponytail/組み込み code-review などとトリガーが重複するため、grilling 単体だけを symlink する terminal-browser と同じパターンを採用した。

## Changes

- `flake.nix`: `mattpocock-skills` (github:mattpocock/skills, flake=false) を flake input として追加
- `profiles/home/claude/default.nix`: `home.file` で `skills/productivity/grilling` のみを `~/.claude/skills/grilling` に symlink し、`permissions.allow` に `"Skill(grilling)"` を追加
- `flake.lock`: 上記 input の pin を反映

## Related Issue

なし